### PR TITLE
Fix issue to only update borrower panel in serve mode

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -151,6 +151,7 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     private void updateBorrowerPanel() {
+        assert logic.isServeMode() : "Not in serve mode";
         ArrayList<Loan> loanList = new ArrayList<>();
         logic.getServingBorrower()
                 .getCurrentLoanList()

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -144,7 +144,6 @@ public class MainWindow extends UiPart<Stage> {
     @FXML
     private void handleServe() {
         mode.setText(SERVE_MODE);
-        updateBorrowerPanel();
     }
 
     /**
@@ -198,8 +197,8 @@ public class MainWindow extends UiPart<Stage> {
                 handleDone();
             }
 
-            if (!commandResult.isDone()) {
-                updateBorrowerPanel(); // throws NotInServeModeException if command is not a serve mode command
+            if (logic.isServeMode() && !commandResult.isDone()) {
+                updateBorrowerPanel();
             }
 
             return commandResult;


### PR DESCRIPTION
- It's on the developers to ensure that we don't update the panel when we are not serving anybody. Therefore, an assertion is now added at the beginning of `updateBorrowerPanel()` method.

-Added logic to ensure we only update when in serve mode