### PR TITLE
Link index to borrower list in ui 

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,9 +8,11 @@ public class Messages {
     //Command messages
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_LOANSTATE_CONSTRAINTS = "Only 1 of -available / -loaned / -overdue flags can "
+    public static final String MESSAGE_LOAN_STATE_CONSTRAINTS = "Only 1 of -available / -loaned / -overdue flags can "
             + "be used at any time";
     public static final String MESSAGE_INVALID_DISPLAY_LIMIT = "Display limit must be a positive integer!";
+    public static final String MESSAGE_BOOK_TITLE_TOO_LONG = "Title of book should not be more than 30 characters!";
+    public static final String MESSAGE_AUTHOR_NAME_TOO_LONG = "Name of author should not be more than 30 characters!";
 
     //Book messages
     public static final String MESSAGE_DUPLICATE_BOOK = "Serial number provided is already in use!";

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -9,7 +9,6 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ReadOnlyCatalog;
 import seedu.address.model.book.Book;
-import seedu.address.model.book.SerialNumber;
 import seedu.address.model.borrower.Borrower;
 
 /**
@@ -41,8 +40,8 @@ public interface Logic {
     /** Returns the borrower being served in Serve Mode, or null if in Normal Mode */
     Borrower getServingBorrower();
 
-    /** Returns the book with the corresponding serial number */
-    Book getBook(SerialNumber sn);
+    /** Returns the list of books borrowed by the borrower being served */
+    ObservableList<Book> getServingBorrowerBookList();
 
     /**
      * Returns the user prefs' catalog file path.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.logging.Logger;
 
+import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
@@ -17,7 +18,6 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyCatalog;
 import seedu.address.model.book.Book;
-import seedu.address.model.book.SerialNumber;
 import seedu.address.model.borrower.Borrower;
 import seedu.address.storage.Storage;
 
@@ -71,8 +71,8 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public Book getBook(SerialNumber sn) {
-        return model.getBook(sn);
+    public ObservableList<Book> getServingBorrowerBookList() {
+        return FXCollections.observableList(model.getBorrowerBooks());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteByIndexCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteByIndexCommand.java
@@ -32,6 +32,10 @@ public class DeleteByIndexCommand extends DeleteCommand {
             throw new CommandException(Messages.MESSAGE_INVALID_BOOK_DISPLAYED_INDEX);
         }
         Book bookToDelete = lastShownList.get(targetIndex.getZeroBased());
+        if (bookToDelete.isCurrentlyLoanedOut()) {
+            // mark book as returned
+            super.markBookAsReturned(model, bookToDelete);
+        }
         model.deleteBook(bookToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_BOOK_SUCCESS, bookToDelete));
     }

--- a/src/main/java/seedu/address/logic/commands/DeleteBySerialNumberCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteBySerialNumberCommand.java
@@ -37,6 +37,10 @@ public class DeleteBySerialNumberCommand extends DeleteCommand {
             throw new CommandException(Messages.MESSAGE_NO_SUCH_BOOK);
         }
         Book bookToDelete = retrieveBookFromCatalog(model, targetSerialNumber);
+        if (bookToDelete.isCurrentlyLoanedOut()) {
+            // mark book as returned
+            super.markBookAsReturned(model, bookToDelete);
+        }
         model.deleteBook(bookToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_BOOK_SUCCESS, bookToDelete));
     }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -1,7 +1,12 @@
 package seedu.address.logic.commands;
 
+import java.time.LocalDate;
+
+import seedu.address.commons.util.DateUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.book.Book;
+import seedu.address.model.loan.Loan;
 
 /**
  * Abstract parent class for DeleteBySerialNumberCommand and DeleteByIndexCommand.
@@ -19,6 +24,26 @@ public abstract class DeleteCommand extends Command {
 
     public static final String MESSAGE_DELETE_BOOK_SUCCESS = "Deleted Book: %1$s";
 
+    private static final int FINE_AMOUNT_ZERO = 0;
+
     public abstract CommandResult execute(Model model) throws CommandException;
+
+    /** Helper method to assist in marking a book as returned before deletion */
+    protected void markBookAsReturned(Model model, Book target) {
+        Loan loanToBeReturned = target.getLoan().get();
+        LocalDate returnDate = DateUtil.getTodayDate();
+        Loan returnedLoan = loanToBeReturned.returnLoan(returnDate, FINE_AMOUNT_ZERO);
+
+        Book returnedBook = target.returnBook();
+
+        // update Book in model to have Loan removed
+        model.setBook(target, returnedBook);
+
+        // remove Loan from Borrower's currentLoanList and move to Borrower's returnedLoanList
+        model.servingBorrowerReturnLoan(loanToBeReturned, returnedLoan);
+
+        // update Loan in LoanRecords with returnDate and remainingFineAmount
+        model.updateLoan(loanToBeReturned, returnedLoan);
+    }
 
 }

--- a/src/main/java/seedu/address/logic/commands/RenewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RenewCommand.java
@@ -59,12 +59,12 @@ public class RenewCommand extends Command {
             throw new CommandException(MESSAGE_NOT_IN_SERVE_MODE);
         }
 
-        List<Book> lastShownList = model.getFilteredBookList();
-        if (index.getZeroBased() >= lastShownList.size()) {
+        List<Book> lastShownBorrowerBooksList = model.getBorrowerBooks();
+        if (index.getZeroBased() >= lastShownBorrowerBooksList.size()) {
             throw new CommandException(MESSAGE_INVALID_BOOK_DISPLAYED_INDEX);
         }
 
-        Book bookToBeRenewed = lastShownList.get(index.getZeroBased()); // TODO change to second list index
+        Book bookToBeRenewed = lastShownBorrowerBooksList.get(index.getZeroBased());
         if (!bookToBeRenewed.isCurrentlyLoanedOut()) {
             throw new CommandException(String.format(MESSAGE_BOOK_NOT_ON_LOAN, bookToBeRenewed));
         }

--- a/src/main/java/seedu/address/logic/commands/ReturnCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ReturnCommand.java
@@ -57,12 +57,12 @@ public class ReturnCommand extends Command {
             throw new CommandException(MESSAGE_NOT_IN_SERVE_MODE);
         }
 
-        List<Book> lastShownList = model.getFilteredBookList();
-        if (index.getZeroBased() >= lastShownList.size()) {
+        List<Book> lastShownBorrowerBooksList = model.getBorrowerBooks();
+        if (index.getZeroBased() >= lastShownBorrowerBooksList.size()) {
             throw new CommandException(MESSAGE_INVALID_BOOK_DISPLAYED_INDEX);
         }
 
-        Book bookToBeReturned = lastShownList.get(index.getZeroBased()); // TODO change to second list index
+        Book bookToBeReturned = lastShownBorrowerBooksList.get(index.getZeroBased());
         if (!bookToBeReturned.isCurrentlyLoanedOut()) {
             throw new CommandException(String.format(MESSAGE_BOOK_NOT_ON_LOAN, bookToBeReturned));
         }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_AUTHOR_NAME_TOO_LONG;
+import static seedu.address.commons.core.Messages.MESSAGE_BOOK_TITLE_TOO_LONG;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_AUTHOR;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GENRE;
@@ -44,7 +46,15 @@ public class AddCommandParser implements Parser<AddCommand> {
         }
 
         Title title = ParserUtil.parseTitle(argMultimap.getValue(PREFIX_TITLE).get());
+        if (title.toString().length() > 30) {
+            throw new ParseException(MESSAGE_BOOK_TITLE_TOO_LONG);
+        }
+
         Author author = ParserUtil.parseAuthor(argMultimap.getValue(PREFIX_AUTHOR).get());
+        if (author.toString().length() > 30) {
+            throw new ParseException(MESSAGE_AUTHOR_NAME_TOO_LONG);
+        }
+
         boolean haveSerialNumber = argMultimap.getValue(PREFIX_SERIAL_NUMBER).isPresent();
         SerialNumber serialNumber;
         if (haveSerialNumber) {

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -122,7 +122,7 @@ public class FindCommandParser implements Parser<FindCommand> {
                 .filter(flag -> flag == Flag.AVAILABLE || flag == Flag.OVERDUE || flag == Flag.LOANED)
                 .collect(Collectors.toList());
         if (loanStates.size() > MAX_LOANSTATE_FLAGS) {
-            throw new ParseException(Messages.MESSAGE_LOANSTATE_CONSTRAINTS);
+            throw new ParseException(Messages.MESSAGE_LOAN_STATE_CONSTRAINTS);
         } else {
             return Optional.of(loanStates.get(0));
         }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -40,7 +40,6 @@ public class ModelManager implements Model {
     private final FilteredList<Book> filteredBooks;
 
     private Optional<Borrower> servingBorrower;
-    private Optional<List<Book>> borrowerBookList;
 
     /**
      * Initializes a ModelManager with the given catalog, loan records, borrower records and userPrefs.
@@ -370,7 +369,6 @@ public class ModelManager implements Model {
     @Override
     public void setServingBorrower(Borrower borrower) {
         this.servingBorrower = Optional.of(borrower);
-        this.borrowerBookList = Optional.of(getBorrowerBooks());
     }
 
     /**

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -461,6 +461,10 @@ public class ModelManager implements Model {
             throw new NotInServeModeException();
         }
 
+        if (servingBorrower.get().getCurrentLoanList().isEmpty()) {
+            return new ArrayList<>();
+        }
+
         ArrayList<Loan> loans = new ArrayList<>();
         servingBorrower.get()
                 .getCurrentLoanList()

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -40,6 +40,7 @@ public class ModelManager implements Model {
     private final FilteredList<Book> filteredBooks;
 
     private Optional<Borrower> servingBorrower;
+    private Optional<List<Book>> borrowerBookList;
 
     /**
      * Initializes a ModelManager with the given catalog, loan records, borrower records and userPrefs.
@@ -362,12 +363,14 @@ public class ModelManager implements Model {
 
     @Override
     public void setServingBorrower(BorrowerId borrowerId) {
-        this.servingBorrower = Optional.of(borrowerRecords.getBorrowerFromId(borrowerId));
+        Borrower borrower = borrowerRecords.getBorrowerFromId(borrowerId);
+        setServingBorrower(borrower);
     }
 
     @Override
     public void setServingBorrower(Borrower borrower) {
         this.servingBorrower = Optional.of(borrower);
+        this.borrowerBookList = Optional.of(getBorrowerBooks());
     }
 
     /**

--- a/src/main/java/seedu/address/model/book/Book.java
+++ b/src/main/java/seedu/address/model/book/Book.java
@@ -201,8 +201,12 @@ public class Book {
         return Objects.hash(title, serialNumber, author, genres);
     }
 
-    @Override
-    public String toString() {
+    /**
+     * Method to return the full string representation of the book, if required.
+     *
+     * @return Full string representation of book.
+     */
+    public String toFullString() {
         final StringBuilder builder = new StringBuilder();
         builder.append(getTitle())
                 .append(", Serial Number: ")
@@ -213,6 +217,21 @@ public class Book {
             builder.append(", Genres: ");
             getGenres().forEach(genre -> builder.append(genre + " "));
         }
+        return builder.toString();
+    }
+
+    /**
+     * Returns display string of Book.
+     *
+     * @return display string of book.
+     */
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+        builder.append("[" + getSerialNumber() + "] ")
+                .append("\"" + getTitle() + "\"")
+                .append(" by ")
+                .append(getAuthor());
         return builder.toString();
     }
 

--- a/src/main/java/seedu/address/model/book/SerialNumberGenerator.java
+++ b/src/main/java/seedu/address/model/book/SerialNumberGenerator.java
@@ -1,6 +1,5 @@
 package seedu.address.model.book;
 
-import java.util.TreeSet;
 import java.util.stream.IntStream;
 
 import seedu.address.model.Catalog;
@@ -11,9 +10,9 @@ import seedu.address.model.Catalog;
 public class SerialNumberGenerator {
     public static final int SERIAL_NUMBER_LENGTH = 5; //excluding prefix 'B'
     public static final String PREFIX = "B";
-    private static final String FIRST_SERIAL_NUMBER = PREFIX + "00001";
 
-    private static TreeSet<SerialNumber> serialNumberTree = new TreeSet<>();
+    private static int currentSerialNumberIndex = 0;
+    private static Catalog catalog;
 
     /**
      * Populates the serial number tree from a catalog.
@@ -21,36 +20,22 @@ public class SerialNumberGenerator {
      * @param catalog catalog to retrieve books from.
      */
     public static void setCatalog(Catalog catalog) {
-        serialNumberTree = new TreeSet<>();
-        catalog.getBookList()
-                .forEach(book -> serialNumberTree.add(book.getSerialNumber()));
+        SerialNumberGenerator.catalog = catalog;
+        currentSerialNumberIndex = 0;
     }
 
     /**
      * Generates a new serial number based on the current serial number index.
      */
     public static SerialNumber generateSerialNumber() {
-        if (serialNumberTree.isEmpty()) {
-            SerialNumber serialNumber = new SerialNumber(FIRST_SERIAL_NUMBER);
-            serialNumberTree.add(serialNumber);
-            return serialNumber;
+        currentSerialNumberIndex++;
+        String padding = getPadding(currentSerialNumberIndex);
+        SerialNumber sn = new SerialNumber(PREFIX + padding + currentSerialNumberIndex);
+        while (catalog.checkIfSerialNumberExists(sn)) {
+            currentSerialNumberIndex++;
+            sn = new SerialNumber(PREFIX + padding + currentSerialNumberIndex);
         }
-        int key = serialNumberTree.size();
-        SerialNumber keyCompare = constructSerialNumberFromInt(key);
-        SerialNumber floorKey = serialNumberTree.floor(keyCompare);
-        SerialNumber newSerialNumber;
-        if (floorKey == null) {
-            newSerialNumber = new SerialNumber(FIRST_SERIAL_NUMBER);
-        } else {
-            int newIndex = floorKey.serialNumberToInt() + 1;
-            newSerialNumber = constructSerialNumberFromInt(newIndex);
-        }
-        serialNumberTree.add(newSerialNumber);
-        return newSerialNumber;
-    }
-
-    private static SerialNumber constructSerialNumberFromInt(int k) {
-        return new SerialNumber(PREFIX + getPadding(k) + k);
+        return sn;
     }
 
     private static String getPadding(int index) {

--- a/src/main/java/seedu/address/model/borrower/Borrower.java
+++ b/src/main/java/seedu/address/model/borrower/Borrower.java
@@ -168,7 +168,7 @@ public class Borrower {
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, borrowerId);
+        return Objects.hash(name, phone, email, borrowerId, currentLoanList, returnedLoanList);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/borrower/BorrowerIdGenerator.java
+++ b/src/main/java/seedu/address/model/borrower/BorrowerIdGenerator.java
@@ -27,7 +27,7 @@ public class BorrowerIdGenerator {
         currentBorrowerIdIndex++;
         String padding = getPadding(currentBorrowerIdIndex);
         BorrowerId id = new BorrowerId(PREFIX + padding + currentBorrowerIdIndex);
-        while (borrowers.checkIfBorrowerIdExists(id)) {
+        while (borrowerIdExists(id)) {
             currentBorrowerIdIndex++;
             id = new BorrowerId(PREFIX + padding + currentBorrowerIdIndex);
         }

--- a/src/main/java/seedu/address/model/borrower/BorrowerIdGenerator.java
+++ b/src/main/java/seedu/address/model/borrower/BorrowerIdGenerator.java
@@ -17,7 +17,7 @@ public class BorrowerIdGenerator {
 
     public static void setBorrowers(BorrowerRecords borrowers) {
         BorrowerIdGenerator.borrowers = borrowers;
-        currentBorrowerIdIndex = borrowers.getSize();
+        currentBorrowerIdIndex = 0;
     }
 
     /**
@@ -25,14 +25,13 @@ public class BorrowerIdGenerator {
      */
     public static BorrowerId generateBorrowerId() {
         currentBorrowerIdIndex++;
-        int paddingLength = getPaddingLength();
-        String padding = getPadding(paddingLength);
+        String padding = getPadding(currentBorrowerIdIndex);
         BorrowerId id = new BorrowerId(PREFIX + padding + currentBorrowerIdIndex);
         while (borrowers.checkIfBorrowerIdExists(id)) {
             currentBorrowerIdIndex++;
             id = new BorrowerId(PREFIX + padding + currentBorrowerIdIndex);
         }
-        return new BorrowerId(PREFIX + padding + currentBorrowerIdIndex);
+        return id;
     }
 
     /**
@@ -42,12 +41,9 @@ public class BorrowerIdGenerator {
         return borrowers.checkIfBorrowerIdExists(id);
     }
 
-    private static int getPaddingLength() {
-        String stringRepresentation = Integer.toString(currentBorrowerIdIndex);
-        return BORROWER_ID_LENGTH - stringRepresentation.length();
-    }
-
-    private static String getPadding(int paddingLength) {
+    private static String getPadding(int index) {
+        String stringRepresentation = Integer.toString(index);
+        int paddingLength = BORROWER_ID_LENGTH - stringRepresentation.length();
         return IntStream.rangeClosed(1, paddingLength)
                 .mapToObj(x -> "0")
                 .reduce("", (a, b) -> a + b);

--- a/src/main/java/seedu/address/model/loan/LoanList.java
+++ b/src/main/java/seedu/address/model/loan/LoanList.java
@@ -45,6 +45,13 @@ public class LoanList implements Iterable<Loan> {
         return loanList.size();
     }
 
+    /**
+     * Returns true if the {@code LoanList} is empty.
+     */
+    public boolean isEmpty() {
+        return loanList.isEmpty();
+    }
+
     public boolean contains(Loan loan) {
         return loanList.contains(loan);
     }

--- a/src/main/java/seedu/address/ui/BorrowerPanel.java
+++ b/src/main/java/seedu/address/ui/BorrowerPanel.java
@@ -10,7 +10,9 @@ import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
+import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
 import seedu.address.commons.util.FineUtil;
 import seedu.address.model.book.Book;
 import seedu.address.model.borrower.Borrower;
@@ -39,6 +41,7 @@ public class BorrowerPanel extends UiPart<Region> {
         name.setText("");
         id.setText("");
         fines.setText("");
+        VBox.setVgrow(bookListView, Priority.ALWAYS);
     }
 
     /**

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -1,11 +1,7 @@
 package seedu.address.ui;
 
-import java.util.ArrayList;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.AnchorPane;
@@ -18,8 +14,6 @@ import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.book.Book;
-import seedu.address.model.loan.Loan;
 
 /**
  * The Main Window. Provides the basic application layout containing
@@ -152,16 +146,7 @@ public class MainWindow extends UiPart<Stage> {
     @FXML
     private void updateBorrowerPanel() {
         assert logic.isServeMode() : "Not in serve mode";
-        ArrayList<Loan> loanList = new ArrayList<>();
-        logic.getServingBorrower()
-                .getCurrentLoanList()
-                .forEach(loan -> loanList.add(loan));
-        ArrayList<Book> bookList = (ArrayList<Book>) loanList.stream()
-                .map(loan -> loan.getBookSerialNumber())
-                .map(sn -> logic.getBook(sn))
-                .collect(Collectors.toList());
-        ObservableList<Book> observableBookList = FXCollections.observableArrayList(bookList);
-        borrowerPanel.setBorrower(logic.getServingBorrower(), observableBookList);
+        borrowerPanel.setBorrower(logic.getServingBorrower(), logic.getServingBorrowerBookList());
     }
 
     /**

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -132,8 +132,7 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
-     * Updates the borrower panel and sets the label to Serve M:w
-     * ode.
+     * Updates the borrower panel and sets the label to Serve Mode.
      */
     @FXML
     private void handleServe() {

--- a/src/main/java/seedu/address/ui/ResultDisplay.java
+++ b/src/main/java/seedu/address/ui/ResultDisplay.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
-import javafx.scene.layout.AnchorPane;
+import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.Region;
 import javafx.scene.paint.Color;
 
@@ -16,7 +16,7 @@ public class ResultDisplay extends UiPart<Region> {
     private static final String FXML = "ResultDisplay.fxml";
 
     @FXML
-    private AnchorPane resultDisplayPlaceholder;
+    private ScrollPane resultDisplayPlaceholder;
 
     @FXML
     private Label resultDisplay;

--- a/src/main/java/seedu/address/ui/ResultDisplay.java
+++ b/src/main/java/seedu/address/ui/ResultDisplay.java
@@ -28,6 +28,7 @@ public class ResultDisplay extends UiPart<Region> {
     public void setFeedbackToUser(String feedbackToUser) {
         requireNonNull(feedbackToUser);
         resultDisplay.setTextFill(Color.web("#FFFFFF"));
+        resultDisplay.setWrapText(true);
         resultDisplay.setText(feedbackToUser);
     }
 

--- a/src/main/resources/view/BorrowerPanel.fxml
+++ b/src/main/resources/view/BorrowerPanel.fxml
@@ -5,7 +5,7 @@
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox fx:id="borrowerPanel" prefWidth="500.0" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1">
+<VBox fx:id="borrowerPanel" prefWidth="500.0" minWidth="500" maxWidth="500" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1">
        <Label fx:id="name" prefHeight="60.0" styleClass="result-display" text="Borrower: ">
          <padding>
             <Insets left="20.0" />

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -15,57 +15,58 @@
 <?import javafx.stage.Stage?>
 
 <fx:root minHeight="600" minWidth="650.0" onCloseRequest="#handleExit" title="LiBerry" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1">
-  <scene>
-    <Scene>
-      <stylesheets>
-        <URL value="@DarkTheme.css" />
-        <URL value="@Extensions.css" />
-      </stylesheets>
+    <scene>
+        <Scene>
+            <stylesheets>
+                <URL value="@DarkTheme.css" />
+                <URL value="@Extensions.css" />
+            </stylesheets>
 
-      <BorderPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="510.0" prefWidth="615.0" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1">
-          <bottom>
-            <AnchorPane fx:id="commandBoxPlaceholder" maxHeight="35.0" minHeight="35.0" minWidth="0.0" prefHeight="35.0" prefWidth="600.0" styleClass="pane-with-border" BorderPane.alignment="CENTER">
-          </AnchorPane>
-        </bottom>
-        <right>
-          <AnchorPane style="-fx-background-color: #d8dae3#d8dae3;" BorderPane.alignment="CENTER">
-                  <children>
-                     <VBox>
+            <BorderPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="510.0" prefWidth="615.0" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1">
+                <bottom>
+                    <AnchorPane fx:id="commandBoxPlaceholder" maxHeight="35.0" minHeight="35.0" minWidth="0.0" prefHeight="35.0" prefWidth="600.0" styleClass="pane-with-border" BorderPane.alignment="CENTER">
+                    </AnchorPane>
+                </bottom>
+                <right>
+                    <VBox maxWidth="500.0" minWidth="500.0" prefWidth="500.0" style="-fx-background-color: #d8dae3#d8dae3;" BorderPane.alignment="CENTER">
                         <children>
-                    <StackPane fx:id="borrowerPanelPlaceholder" VBox.vgrow="ALWAYS" />
+                            <VBox VBox.vgrow="ALWAYS">
+                                <children>
+                                    <StackPane fx:id="borrowerPanelPlaceholder" VBox.vgrow="ALWAYS" />
+                                </children>
+                            </VBox>
                         </children>
-                     </VBox>
-                  </children></AnchorPane>
-        </right>
-        <center>
-            <VBox fx:id="bookList" minWidth="500.0" prefWidth="500.0" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
-                <padding>
-                    <Insets bottom="10" left="10" right="10" top="10" />
-                </padding>
-                <StackPane fx:id="bookListPanelPlaceholder" VBox.vgrow="ALWAYS" />
-                 <Pane fx:id="resultDisplayPlaceholder" maxHeight="150.0" minHeight="150.0" prefHeight="120.0">
-                     <padding>
-                        <Insets left="20.0" />
-                     </padding></Pane>
-            </VBox>
-        </center>
-            <top>
-               <HBox prefHeight="47.0" prefWidth="615.0" BorderPane.alignment="CENTER">
-                  <children>
-                     <ImageView fitHeight="47.0" fitWidth="118.0" pickOnBounds="true" preserveRatio="true" HBox.hgrow="NEVER">
-                        <image>
-                           <Image url="@../images/LiBerryLogo.png" />
-                        </image>
-                        <HBox.margin>
-                           <Insets left="7.0" top="7.0" />
-                        </HBox.margin>
-                     </ImageView>
-                     <Pane prefHeight="47.0" prefWidth="286.0" HBox.hgrow="ALWAYS" />
-                     <Label fx:id="mode" prefHeight="47.0" prefWidth="201.0" />
-                  </children>
-               </HBox>
-            </top>
-      </BorderPane>
-    </Scene>
-  </scene>
+                    </VBox>
+                </right>
+                <center>
+                    <VBox fx:id="bookList" minWidth="500.0" prefWidth="500.0" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
+                        <padding>
+                            <Insets bottom="10" left="10" right="10" top="10" />
+                        </padding>
+                        <StackPane fx:id="bookListPanelPlaceholder" VBox.vgrow="ALWAYS" />
+                        <Pane fx:id="resultDisplayPlaceholder" maxHeight="150.0" minHeight="150.0" prefHeight="120.0">
+                            <padding>
+                                <Insets left="20.0" />
+                            </padding></Pane>
+                    </VBox>
+                </center>
+                <top>
+                    <HBox prefHeight="47.0" prefWidth="615.0" BorderPane.alignment="CENTER">
+                        <children>
+                            <ImageView fitHeight="47.0" fitWidth="118.0" pickOnBounds="true" preserveRatio="true" HBox.hgrow="NEVER">
+                                <image>
+                                    <Image url="@../images/LiBerryLogo.png" />
+                                </image>
+                                <HBox.margin>
+                                    <Insets left="7.0" top="7.0" />
+                                </HBox.margin>
+                            </ImageView>
+                            <Pane prefHeight="47.0" prefWidth="286.0" HBox.hgrow="ALWAYS" />
+                            <Label fx:id="mode" prefHeight="47.0" prefWidth="201.0" />
+                        </children>
+                    </HBox>
+                </top>
+            </BorderPane>
+        </Scene>
+    </scene>
 </fx:root>

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -2,13 +2,8 @@
 
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
-<?import javafx.scene.layout.Region?>
 
-<Label fx:id="resultDisplay" maxHeight="150.0" minHeight="150.0" minWidth="600.0" prefHeight="150.0" styleClass="result-display" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1">
-    <minWidth>
-        <!-- Ensures that the label text is never truncated -->
-        <Region fx:constant="USE_COMPUTED_SIZE" />
-    </minWidth>
+<Label fx:id="resultDisplay" maxHeight="150.0" minHeight="150.0" minWidth="-Infinity" prefHeight="150.0" styleClass="result-display" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1">
    <padding>
       <Insets left="10.0" />
    </padding>

--- a/src/test/java/seedu/address/logic/commands/LoanCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/LoanCommandTest.java
@@ -10,9 +10,10 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_SERIAL_NUMBER_B
 import static seedu.address.logic.commands.CommandTestUtil.VALID_SERIAL_NUMBER_BOOK_2;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalBooks.BOOK_1;
-import static seedu.address.testutil.TypicalBooks.BOOK_7_ON_LOAN;
+import static seedu.address.testutil.TypicalBooks.BOOK_7;
 import static seedu.address.testutil.TypicalBooks.getTypicalCatalog;
 import static seedu.address.testutil.TypicalBorrowers.HOON;
+import static seedu.address.testutil.TypicalLoans.LOAN_7;
 import static seedu.address.testutil.UserSettingsBuilder.DEFAULT_LOAN_PERIOD;
 
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,7 @@ import seedu.address.model.borrower.BorrowerId;
 import seedu.address.model.loan.Loan;
 import seedu.address.model.loan.LoanId;
 import seedu.address.model.loan.LoanList;
+import seedu.address.testutil.BookBuilder;
 
 class LoanCommandTest {
 
@@ -118,12 +120,13 @@ class LoanCommandTest {
 
     @Test
     public void execute_bookAlreadyOnLoan_loanUnsuccessful() {
-        SerialNumber toLoan = BOOK_7_ON_LOAN.getSerialNumber();
+        SerialNumber toLoan = BOOK_7.getSerialNumber();
         BorrowerRecords borrowerRecords = new BorrowerRecords();
         borrowerRecords.addBorrower(HOON);
         BorrowerId servingBorrowerId = HOON.getBorrowerId();
         Catalog catalog = new Catalog();
-        catalog.addBook(BOOK_7_ON_LOAN);
+        Book onLoan = new BookBuilder(BOOK_7).withLoan(LOAN_7).build();
+        catalog.addBook(onLoan);
 
         Model model = new ModelManager(catalog, new LoanRecords(),
                 borrowerRecords, new UserPrefs());
@@ -137,7 +140,7 @@ class LoanCommandTest {
         } catch (CommandException e) {
             actualMessage = e.getMessage();
         }
-        String expectedMessage = String.format(MESSAGE_BOOK_ON_LOAN, BOOK_7_ON_LOAN);
+        String expectedMessage = String.format(MESSAGE_BOOK_ON_LOAN, BOOK_7);
         assertEquals(actualMessage, expectedMessage);
     }
 

--- a/src/test/java/seedu/address/logic/commands/RenewCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RenewCommandTest.java
@@ -5,15 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_BOOK_CANNOT_BE_RENEWED_ANYMORE;
 import static seedu.address.commons.core.Messages.MESSAGE_BOOK_IS_OVERDUE;
-import static seedu.address.commons.core.Messages.MESSAGE_BOOK_NOT_ON_LOAN;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_BOOK_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_NOT_IN_SERVE_MODE;
-import static seedu.address.commons.core.Messages.MESSAGE_NOT_LOANED_BY_BORROWER;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalBooks.BOOK_6;
-import static seedu.address.testutil.TypicalBooks.BOOK_7_ON_LOAN;
-import static seedu.address.testutil.TypicalBorrowers.HOON;
+import static seedu.address.testutil.TypicalBooks.BOOK_7;
 import static seedu.address.testutil.TypicalBorrowers.IDA;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_BOOK;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_BOOK;
@@ -54,7 +50,8 @@ class RenewCommandTest {
         BorrowerId servingBorrowerId = IDA.getBorrowerId();
 
         Catalog catalog = new Catalog();
-        catalog.addBook(BOOK_7_ON_LOAN);
+        Book onLoan = new BookBuilder(BOOK_7).withLoan(LOAN_7).build();
+        catalog.addBook(onLoan);
 
         LoanRecords loanRecords = new LoanRecords();
         loanRecords.addLoan(LOAN_7);
@@ -71,9 +68,9 @@ class RenewCommandTest {
         Loan renewedLoan = new LoanBuilder(LOAN_7).withDueDate(extendedDueDate.toString())
                 .withRenewCount(1).build();
 
-        Book renewedBook = new BookBuilder(BOOK_7_ON_LOAN).withLoan(renewedLoan).build();
+        Book renewedBook = new BookBuilder(BOOK_7).withLoan(renewedLoan).build();
 
-        expectedModel.setBook(BOOK_7_ON_LOAN, renewedBook);
+        expectedModel.setBook(BOOK_7, renewedBook);
         expectedModel.servingBorrowerRenewLoan(LOAN_7, renewedLoan);
         expectedModel.updateLoan(LOAN_7, renewedLoan);
 
@@ -89,7 +86,8 @@ class RenewCommandTest {
         borrowerRecords.addBorrower(IDA);
 
         Catalog catalog = new Catalog();
-        catalog.addBook(BOOK_7_ON_LOAN);
+        Book onLoan = new BookBuilder(BOOK_7).withLoan(LOAN_7).build();
+        catalog.addBook(onLoan);
 
         LoanRecords loanRecords = new LoanRecords();
         loanRecords.addLoan(LOAN_7);
@@ -115,7 +113,8 @@ class RenewCommandTest {
         BorrowerId servingBorrowerId = IDA.getBorrowerId();
 
         Catalog catalog = new Catalog();
-        catalog.addBook(BOOK_7_ON_LOAN);
+        Book onLoan = new BookBuilder(BOOK_7).withLoan(LOAN_7).build();
+        catalog.addBook(onLoan);
 
         LoanRecords loanRecords = new LoanRecords();
         loanRecords.addLoan(LOAN_7);
@@ -136,66 +135,13 @@ class RenewCommandTest {
     }
 
     @Test
-    public void execute_bookNotOnLoan_renewUnsuccessful() {
-        BorrowerRecords borrowerRecords = new BorrowerRecords();
-        borrowerRecords.addBorrower(IDA);
-        BorrowerId servingBorrowerId = IDA.getBorrowerId();
-
-        Catalog catalog = new Catalog();
-        catalog.addBook(BOOK_6);
-
-        LoanRecords loanRecords = new LoanRecords();
-
-        Model model = new ModelManager(catalog, loanRecords, borrowerRecords, new UserPrefs());
-        model.setServingBorrower(servingBorrowerId);
-
-        RenewCommand renewCommand = new RenewCommand(INDEX_FIRST_BOOK);
-
-        String actualMessage;
-        try {
-            actualMessage = renewCommand.execute(model).getFeedbackToUser();
-        } catch (CommandException e) {
-            actualMessage = e.getMessage();
-        }
-        String expectedMessage = String.format(MESSAGE_BOOK_NOT_ON_LOAN, BOOK_6);
-        assertEquals(actualMessage, expectedMessage);
-    }
-
-    @Test
-    public void execute_borrowerDoesNotLoanThisBook_unsuccessful() {
-        BorrowerRecords borrowerRecords = new BorrowerRecords();
-        borrowerRecords.addBorrower(HOON);
-        BorrowerId servingBorrowerId = HOON.getBorrowerId();
-
-        Catalog catalog = new Catalog();
-        catalog.addBook(BOOK_7_ON_LOAN);
-
-        LoanRecords loanRecords = new LoanRecords();
-        loanRecords.addLoan(LOAN_7);
-
-        Model model = new ModelManager(catalog, loanRecords, borrowerRecords, new UserPrefs());
-        model.setServingBorrower(servingBorrowerId);
-
-        RenewCommand renewCommand = new RenewCommand(INDEX_FIRST_BOOK);
-
-        String actualMessage;
-        try {
-            actualMessage = renewCommand.execute(model).getFeedbackToUser();
-        } catch (CommandException e) {
-            actualMessage = e.getMessage();
-        }
-        String expectedMessage = String.format(MESSAGE_NOT_LOANED_BY_BORROWER, HOON, BOOK_7_ON_LOAN);
-        assertEquals(actualMessage, expectedMessage);
-    }
-
-    @Test
     public void execute_maxRenewsMet_renewUnsuccessful() {
         LoanRecords loanRecords = new LoanRecords();
         Loan maxRenewedLoan = new LoanBuilder(LOAN_7).withRenewCount(3).build();
         loanRecords.addLoan(maxRenewedLoan);
 
         Catalog catalog = new Catalog();
-        Book maxRenewedBook = new BookBuilder(BOOK_7_ON_LOAN).withLoan(maxRenewedLoan).build();
+        Book maxRenewedBook = new BookBuilder(BOOK_7).withLoan(maxRenewedLoan).build();
         catalog.addBook(maxRenewedBook);
 
         BorrowerRecords borrowerRecords = new BorrowerRecords();
@@ -225,7 +171,7 @@ class RenewCommandTest {
         loanRecords.addLoan(overdueLoan);
 
         Catalog catalog = new Catalog();
-        Book overdueBook = new BookBuilder(BOOK_7_ON_LOAN).withLoan(overdueLoan).build();
+        Book overdueBook = new BookBuilder(BOOK_7).withLoan(overdueLoan).build();
         catalog.addBook(overdueBook);
 
         BorrowerRecords borrowerRecords = new BorrowerRecords();

--- a/src/test/java/seedu/address/logic/commands/ReturnCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ReturnCommandTest.java
@@ -98,14 +98,7 @@ class ReturnCommandTest {
         borrowerRecords.addBorrower(IDA);
         BorrowerId servingBorrowerId = IDA.getBorrowerId();
 
-        Catalog catalog = new Catalog();
-        Book onLoan = new BookBuilder(BOOK_7).withLoan(LOAN_7).build();
-        catalog.addBook(onLoan);
-
-        LoanRecords loanRecords = new LoanRecords();
-        loanRecords.addLoan(LOAN_7);
-
-        Model model = new ModelManager(catalog, loanRecords, borrowerRecords, new UserPrefs());
+        Model model = new ModelManager(new Catalog(), new LoanRecords(), borrowerRecords, new UserPrefs());
         model.setServingBorrower(servingBorrowerId);
 
         ReturnCommand returnCommand = new ReturnCommand(INDEX_SECOND_BOOK);

--- a/src/test/java/seedu/address/logic/commands/ReturnCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ReturnCommandTest.java
@@ -92,6 +92,7 @@ class ReturnCommandTest {
         assertEquals(actualMessage, expectedMessage);
     }
 
+    /*
     @Test
     public void execute_noSuchIndex_returnUnsuccessful() {
         BorrowerRecords borrowerRecords = new BorrowerRecords();
@@ -112,6 +113,7 @@ class ReturnCommandTest {
         String expectedMessage = MESSAGE_INVALID_BOOK_DISPLAYED_INDEX;
         assertEquals(expectedMessage, actualMessage);
     }
+    */
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/address/logic/commands/ReturnCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ReturnCommandTest.java
@@ -3,7 +3,7 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-//import static seedu.address.commons.core.Messages.MESSAGE_INVALID_BOOK_DISPLAYED_INDEX;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_BOOK_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_NOT_IN_SERVE_MODE;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalBooks.BOOK_7;
@@ -92,7 +92,6 @@ class ReturnCommandTest {
         assertEquals(actualMessage, expectedMessage);
     }
 
-    /*
     @Test
     public void execute_noSuchIndex_returnUnsuccessful() {
         BorrowerRecords borrowerRecords = new BorrowerRecords();
@@ -113,7 +112,6 @@ class ReturnCommandTest {
         String expectedMessage = MESSAGE_INVALID_BOOK_DISPLAYED_INDEX;
         assertEquals(expectedMessage, actualMessage);
     }
-    */
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/address/logic/commands/ReturnCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ReturnCommandTest.java
@@ -105,7 +105,7 @@ class ReturnCommandTest {
         LoanRecords loanRecords = new LoanRecords();
         loanRecords.addLoan(LOAN_7);
 
-        Model model = new ModelManager(new Catalog(), new LoanRecords(), borrowerRecords, new UserPrefs());
+        Model model = new ModelManager(catalog, loanRecords, borrowerRecords, new UserPrefs());
         model.setServingBorrower(servingBorrowerId);
 
         ReturnCommand returnCommand = new ReturnCommand(INDEX_SECOND_BOOK);

--- a/src/test/java/seedu/address/logic/commands/ReturnCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ReturnCommandTest.java
@@ -98,6 +98,13 @@ class ReturnCommandTest {
         borrowerRecords.addBorrower(IDA);
         BorrowerId servingBorrowerId = IDA.getBorrowerId();
 
+        Catalog catalog = new Catalog();
+        Book onLoan = new BookBuilder(BOOK_7).withLoan(LOAN_7).build();
+        catalog.addBook(onLoan);
+
+        LoanRecords loanRecords = new LoanRecords();
+        loanRecords.addLoan(LOAN_7);
+
         Model model = new ModelManager(new Catalog(), new LoanRecords(), borrowerRecords, new UserPrefs());
         model.setServingBorrower(servingBorrowerId);
 

--- a/src/test/java/seedu/address/logic/commands/ReturnCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ReturnCommandTest.java
@@ -3,7 +3,7 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_BOOK_DISPLAYED_INDEX;
+//import static seedu.address.commons.core.Messages.MESSAGE_INVALID_BOOK_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_NOT_IN_SERVE_MODE;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalBooks.BOOK_7;

--- a/src/test/java/seedu/address/logic/commands/ReturnCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ReturnCommandTest.java
@@ -3,14 +3,10 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.commons.core.Messages.MESSAGE_BOOK_NOT_ON_LOAN;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_BOOK_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_NOT_IN_SERVE_MODE;
-import static seedu.address.commons.core.Messages.MESSAGE_NOT_LOANED_BY_BORROWER;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalBooks.BOOK_6;
-import static seedu.address.testutil.TypicalBooks.BOOK_7_ON_LOAN;
-import static seedu.address.testutil.TypicalBorrowers.HOON;
+import static seedu.address.testutil.TypicalBooks.BOOK_7;
 import static seedu.address.testutil.TypicalBorrowers.IDA;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_BOOK;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_BOOK;
@@ -44,19 +40,18 @@ class ReturnCommandTest {
         BorrowerId servingBorrowerId = IDA.getBorrowerId();
 
         Catalog catalog = new Catalog();
-        catalog.addBook(BOOK_7_ON_LOAN);
+        Book onLoan = new BookBuilder(BOOK_7).withLoan(LOAN_7).build();
+        catalog.addBook(onLoan);
 
         LoanRecords loanRecords = new LoanRecords();
         loanRecords.addLoan(LOAN_7);
-
-        Book loanedBook = new BookBuilder(BOOK_7_ON_LOAN).build();
 
         Model model = new ModelManager(catalog, loanRecords, borrowerRecords, new UserPrefs());
         model.setServingBorrower(servingBorrowerId);
 
         ReturnCommand returnCommand = new ReturnCommand(INDEX_FIRST_BOOK);
 
-        Book returnedBook = loanedBook.returnBook();
+        Book returnedBook = onLoan.returnBook();
 
         String actualMessage;
         try {
@@ -77,7 +72,8 @@ class ReturnCommandTest {
         borrowerRecords.addBorrower(IDA);
 
         Catalog catalog = new Catalog();
-        catalog.addBook(BOOK_7_ON_LOAN);
+        Book onLoan = new BookBuilder(BOOK_7).withLoan(LOAN_7).build();
+        catalog.addBook(onLoan);
 
         LoanRecords loanRecords = new LoanRecords();
         loanRecords.addLoan(LOAN_7);
@@ -103,7 +99,8 @@ class ReturnCommandTest {
         BorrowerId servingBorrowerId = IDA.getBorrowerId();
 
         Catalog catalog = new Catalog();
-        catalog.addBook(BOOK_7_ON_LOAN);
+        Book onLoan = new BookBuilder(BOOK_7).withLoan(LOAN_7).build();
+        catalog.addBook(onLoan);
 
         LoanRecords loanRecords = new LoanRecords();
         loanRecords.addLoan(LOAN_7);
@@ -120,60 +117,7 @@ class ReturnCommandTest {
             actualMessage = e.getMessage();
         }
         String expectedMessage = MESSAGE_INVALID_BOOK_DISPLAYED_INDEX;
-        assertEquals(actualMessage, expectedMessage);
-    }
-
-    @Test
-    public void execute_bookNotOnLoan_returnUnsuccessful() {
-        BorrowerRecords borrowerRecords = new BorrowerRecords();
-        borrowerRecords.addBorrower(IDA);
-        BorrowerId servingBorrowerId = IDA.getBorrowerId();
-
-        Catalog catalog = new Catalog();
-        catalog.addBook(BOOK_6);
-
-        LoanRecords loanRecords = new LoanRecords();
-
-        Model model = new ModelManager(catalog, loanRecords, borrowerRecords, new UserPrefs());
-        model.setServingBorrower(servingBorrowerId);
-
-        ReturnCommand returnCommand = new ReturnCommand(INDEX_FIRST_BOOK);
-
-        String actualMessage;
-        try {
-            actualMessage = returnCommand.execute(model).getFeedbackToUser();
-        } catch (CommandException e) {
-            actualMessage = e.getMessage();
-        }
-        String expectedMessage = String.format(MESSAGE_BOOK_NOT_ON_LOAN, BOOK_6);
-        assertEquals(actualMessage, expectedMessage);
-    }
-
-    @Test
-    public void execute_borrowerDoesNotLoanThisBook_unsuccessful() {
-        BorrowerRecords borrowerRecords = new BorrowerRecords();
-        borrowerRecords.addBorrower(HOON);
-        BorrowerId servingBorrowerId = HOON.getBorrowerId();
-
-        Catalog catalog = new Catalog();
-        catalog.addBook(BOOK_7_ON_LOAN);
-
-        LoanRecords loanRecords = new LoanRecords();
-        loanRecords.addLoan(LOAN_7);
-
-        Model model = new ModelManager(catalog, loanRecords, borrowerRecords, new UserPrefs());
-        model.setServingBorrower(servingBorrowerId);
-
-        ReturnCommand returnCommand = new ReturnCommand(INDEX_FIRST_BOOK);
-
-        String actualMessage;
-        try {
-            actualMessage = returnCommand.execute(model).getFeedbackToUser();
-        } catch (CommandException e) {
-            actualMessage = e.getMessage();
-        }
-        String expectedMessage = String.format(MESSAGE_NOT_LOANED_BY_BORROWER, HOON, BOOK_7_ON_LOAN);
-        assertEquals(actualMessage, expectedMessage);
+        assertEquals(expectedMessage, actualMessage);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_BOOK_TITLE_TOO_LONG;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.AUTHOR_DESC_BOOK_1;
 import static seedu.address.logic.commands.CommandTestUtil.AUTHOR_DESC_BOOK_2;
@@ -16,6 +17,7 @@ import static seedu.address.logic.commands.CommandTestUtil.TITLE_DESC_BOOK_2;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_AUTHOR_BOOK_2;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_GENRE_ACTION;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_GENRE_FICTION;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_SERIAL_NUMBER_BOOK_1;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_SERIAL_NUMBER_BOOK_2;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TITLE_BOOK_2;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -34,6 +36,10 @@ import seedu.address.model.genre.Genre;
 import seedu.address.testutil.BookBuilder;
 
 public class AddCommandParserTest {
+    private static final String EXTRA_CHAR = "a";
+    private static final String LONG_TITLE_BOOK = "qwertyuiopasdfghjklzxcvbnmqwer"; // 30 char long
+    private static final String LONG_TITLE_DESC_BOOK = " t/qwertyuiopasdfghjklzxcvbnmqwer"; // 30 char long with prefix
+
     private AddCommandParser parser = new AddCommandParser();
 
     @Test
@@ -102,4 +108,22 @@ public class AddCommandParserTest {
                 + AUTHOR_DESC_BOOK_2 + GENRE_DESC_ACTION + GENRE_DESC_FICTION,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
+
+    @Test
+    public void parse_titleTooLong_failure() {
+        assertParseFailure(parser, LONG_TITLE_DESC_BOOK + EXTRA_CHAR + SERIAL_NUMBER_DESC_BOOK_1 + AUTHOR_DESC_BOOK_2
+                + GENRE_DESC_ACTION + GENRE_DESC_FICTION, MESSAGE_BOOK_TITLE_TOO_LONG);
+    }
+
+    @Test
+    public void parse_titleCorrectLength_success() {
+        Book toAdd = new BookBuilder()
+                .withTitle(LONG_TITLE_BOOK)
+                .withSerialNumber(VALID_SERIAL_NUMBER_BOOK_1)
+                .withAuthor(VALID_AUTHOR_BOOK_2)
+                .build();
+        assertParseSuccess(parser, LONG_TITLE_DESC_BOOK + SERIAL_NUMBER_DESC_BOOK_1 + AUTHOR_DESC_BOOK_2,
+                new AddCommand(toAdd));
+    }
+
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -61,7 +61,7 @@ public class FindCommandParserTest {
     @Test
     public void parse_duplicateLoanState_throwsParseException() {
         assertParseFailure(parser, " -loaned -available",
-                Messages.MESSAGE_LOANSTATE_CONSTRAINTS);
+                Messages.MESSAGE_LOAN_STATE_CONSTRAINTS);
     }
 
 }

--- a/src/test/java/seedu/address/model/book/BookTest.java
+++ b/src/test/java/seedu/address/model/book/BookTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_AUTHOR_BOOK_2;
-//import static seedu.address.logic.commands.CommandTestUtil.VALID_BORROWER_ID;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_GENRE_ACTION;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_SERIAL_NUMBER_BOOK_1;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_SERIAL_NUMBER_BOOK_2;
@@ -14,10 +13,6 @@ import static seedu.address.testutil.TypicalBooks.BOOK_1;
 import static seedu.address.testutil.TypicalBooks.BOOK_2;
 
 import org.junit.jupiter.api.Test;
-
-//import seedu.address.commons.util.DateUtil;
-//import seedu.address.model.borrower.BorrowerId;
-//import seedu.address.model.loan.Loan;
 
 import seedu.address.testutil.BookBuilder;
 
@@ -30,16 +25,16 @@ public class BookTest {
     }
 
     @Test
-    public void noGenres_toString_noTagFieldDisplayed() {
-        Book book = new BookBuilder().withGenres().build();
-        boolean containsTag = book.toString().contains("Genres");
-        assertFalse(containsTag);
+    public void toString_haveTitleDisplayed() {
+        Book book = new BookBuilder(BOOK_1).build();
+        boolean containsTag = book.toString().contains(book.getTitle().toString());
+        assertTrue(containsTag);
     }
 
     @Test
-    public void haveGenres_toString_haveTagFieldDisplayed() {
-        Book book = new BookBuilder().withGenres("Action").build();
-        boolean containsTag = book.toString().contains("Genres");
+    public void toString_haveAuthorDisplayed() {
+        Book book = new BookBuilder(BOOK_1).build();
+        boolean containsTag = book.toString().contains(book.getAuthor().toString());
         assertTrue(containsTag);
     }
 
@@ -133,10 +128,12 @@ public class BookTest {
         Book book1 = new BookBuilder(BOOK_1).build();
         StringBuilder genres = new StringBuilder();
         book1.getGenres().forEach(genre -> genres.append(genre + " "));
-        String stringRep = book1.getTitle()
-                + ", Serial Number: " + book1.getSerialNumber()
-                + ", Author: " + book1.getAuthor()
-                + ", Genres: " + genres.toString();
+        String stringRep = "["
+                + book1.getSerialNumber().toString()
+                + "] \""
+                + book1.getTitle().toString()
+                + "\" by "
+                + book1.getAuthor().toString();
 
         assertTrue(book1.toString().equals(stringRep));
     }

--- a/src/test/java/seedu/address/model/book/SerialNumberGeneratorTest.java
+++ b/src/test/java/seedu/address/model/book/SerialNumberGeneratorTest.java
@@ -36,14 +36,4 @@ class SerialNumberGeneratorTest {
         assertEquals(SerialNumberGenerator.generateSerialNumber(), new SerialNumber("B00005"));
         assertEquals(SerialNumberGenerator.generateSerialNumber(), new SerialNumber("B00007"));
     }
-
-    @Test
-    void generateSerialNumber_nullFloorKey_success() {
-        Catalog catalog = new Catalog();
-        Book newBook = new BookBuilder().withTitle("testBook").withSerialNumber("B00006").build();
-        catalog.addBook(newBook);
-        SerialNumberGenerator.setCatalog(catalog);
-        assertEquals(SerialNumberGenerator.generateSerialNumber(), new SerialNumber("B00001"));
-        assertEquals(SerialNumberGenerator.generateSerialNumber(), new SerialNumber("B00002"));
-    }
 }

--- a/src/test/java/seedu/address/model/borrower/BorrowerIdTest.java
+++ b/src/test/java/seedu/address/model/borrower/BorrowerIdTest.java
@@ -1,10 +1,14 @@
 package seedu.address.model.borrower;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalBorrowers.BOB;
 
 import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.BorrowerBuilder;
 
 public class BorrowerIdTest {
 
@@ -36,5 +40,11 @@ public class BorrowerIdTest {
         assertTrue(BorrowerId.isValidBorrowerId("K0911")); // exactly 3 numbers
         assertTrue(BorrowerId.isValidBorrowerId("K0001")); //smallest Borrower ID
         assertTrue(BorrowerId.isValidBorrowerId("K9999")); // largest Borrower ID
+    }
+
+    @Test
+    public void hashcode_sameBorrowerSameHashcode() {
+        Borrower toCompare = new BorrowerBuilder(BOB).build();
+        assertEquals(BOB.hashCode(), toCompare.hashCode());
     }
 }

--- a/src/test/java/seedu/address/model/util/SampleDataUtilTest.java
+++ b/src/test/java/seedu/address/model/util/SampleDataUtilTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.BorrowerRecords;
 import seedu.address.model.Catalog;
 import seedu.address.model.LoanRecords;
+import seedu.address.model.ReadOnlyCatalog;
 
 class SampleDataUtilTest {
 
@@ -16,6 +17,7 @@ class SampleDataUtilTest {
     public void getSampleCatalog_containsSampleBooks() {
         Catalog sampleAb = new Catalog();
         Arrays.stream(SampleDataUtil.getSampleBooks()).forEach(book -> sampleAb.addBook(book));
+        ReadOnlyCatalog b = SampleDataUtil.getSampleCatalog();
         assertEquals(sampleAb, SampleDataUtil.getSampleCatalog());
     }
 

--- a/src/test/java/seedu/address/testutil/TypicalBooks.java
+++ b/src/test/java/seedu/address/testutil/TypicalBooks.java
@@ -1,7 +1,5 @@
 package seedu.address.testutil;
 
-import static seedu.address.testutil.TypicalLoans.LOAN_7;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -26,9 +24,9 @@ public class TypicalBooks {
             .withSerialNumber("B00005").withAuthor("Jin Yong").withGenres("FICTION", "ACTION").build();
     public static final Book BOOK_6 = new BookBuilder().withTitle("My Book")
             .withSerialNumber("B00006").withAuthor("Jin Yong").withGenres("FICTION", "ACTION").build();
-    public static final Book BOOK_7_ON_LOAN = new BookBuilder().withTitle("The Hunger Games")
+    public static final Book BOOK_7 = new BookBuilder().withTitle("The Hunger Games")
             .withSerialNumber("B00007").withAuthor("Suzanne Collins")
-            .withGenres("FICTION", "ACTION").withLoan(LOAN_7).build();
+            .withGenres("FICTION", "ACTION").build();
 
     private TypicalBooks() {} // prevents instantiation
 

--- a/src/test/java/seedu/address/testutil/TypicalBorrowers.java
+++ b/src/test/java/seedu/address/testutil/TypicalBorrowers.java
@@ -64,8 +64,6 @@ public class TypicalBorrowers {
     public static final Borrower BOB = new BorrowerBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
             .withEmail(VALID_EMAIL_BOB).withBorrowerId(VALID_ID_BOB).build();
 
-    public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
-
     private TypicalBorrowers() {} // prevents instantiation
 
     /**


### PR DESCRIPTION
- For commands `return` and `renew`, the given parameter `INDEX` now refers to the borrower's loaned list instead of the main catalog list.

- Fixed bug in serial number generator to generate the correct next serial number

- Added restriction to book title and author (30 char max) so as to accommodate to UI and loan slip

- Removed irrelevant tests in `RenewCommandTest` and `ReturnCommandTest` (eg. Returning a book that is not loaned by the borrower is not possible when using the return command with index from the borrower's own book)