### PR TITLE
Add today's date to loan slip, loan slip shows renews, limit entry lengths

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -284,7 +284,7 @@ Loans the book with serial number B00041 to the currently served borrower.
 * `loan sn/B00201 sn/B02929 sn/B00203` - Coming in v2.0 +
 Loans the books with serial numbers B00201, B02929 and B00203 to the currently served borrower.
 
-After loaning all books, upon the `DONE` command, a printable loan slip in pdf format will be generated.
+After loaning all books, upon the `DONE` command, a printable loan slip in pdf format will be generated. The loan slip will be opened in your computer's pdf viewer and also saved in the `loan_slips` folder.
 
 ****
 .Printable loan slip generated.

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -137,7 +137,7 @@ Adds a new book to library records. +
 Format: `add t/TITLE a/AUTHOR [sn/BOOK_SN] [g/GENRE]...`
 
 [TIP]
-A book can have any number of genres (including 0).
+A book can have up to 5 genres (but can have no genres as well).
 
 [TIP]
 You do not need to specify the serial number if you wish so. +

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -29,8 +29,6 @@ public class Messages {
     public static final String MESSAGE_DUPLICATE_BORROWER = "Phone/Email is already in used! ";
     public static final String MESSAGE_NO_SUCH_BORROWER_ID = "No such borrower ID!";
     public static final String MESSAGE_NOT_IN_SERVE_MODE = "Not in Serve mode! Enter Serve mode to use this command!";
-    public static final String MESSAGE_STILL_IN_SERVE_MODE = "Still serving %1$s! Exit serve mode using 'Done' before"
-            + " serving someone else!";
 
     // Loan messages
     public static final String MESSAGE_BOOK_ON_LOAN = "%1$s is already on loan!";

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -29,6 +29,8 @@ public class Messages {
     public static final String MESSAGE_DUPLICATE_BORROWER = "Phone/Email is already in used! ";
     public static final String MESSAGE_NO_SUCH_BORROWER_ID = "No such borrower ID!";
     public static final String MESSAGE_NOT_IN_SERVE_MODE = "Not in Serve mode! Enter Serve mode to use this command!";
+    public static final String MESSAGE_STILL_IN_SERVE_MODE = "Still serving %1$s! Exit serve mode using 'Done' before"
+            + " serving someone else!";
 
     // Loan messages
     public static final String MESSAGE_BOOK_ON_LOAN = "%1$s is already on loan!";

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -15,6 +15,8 @@ public class Messages {
     public static final String MESSAGE_AUTHOR_NAME_TOO_LONG = "Name of author should not be more than 30 characters!";
     public static final String MESSAGE_UNUSED_ARGUMENT = "\n\'%1$s\' is ignored as \'%2$s\'"
             + " does not accept arguments";
+    public static final String MESSAGE_TOO_MANY_GENRES =
+            "Too many genres specified! The maximum number of genres is %1$d.";
 
     // Book messages
     public static final String MESSAGE_DUPLICATE_BOOK = "Serial number provided is already in use!";

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -18,7 +18,7 @@ public class Messages {
 
     // Book messages
     public static final String MESSAGE_DUPLICATE_BOOK = "Serial number provided is already in use!";
-    public static final String MESSAGE_INVALID_BOOK_DISPLAYED_INDEX = "The book index provided is invalid";
+    public static final String MESSAGE_INVALID_BOOK_DISPLAYED_INDEX = "The book index provided is invalid!";
     public static final String MESSAGE_BOOKS_LISTED_OVERVIEW = "%1$d books listed!";
     public static final String MESSAGE_NO_SUCH_BOOK = "No such book!";
 

--- a/src/main/java/seedu/address/commons/util/DateUtil.java
+++ b/src/main/java/seedu/address/commons/util/DateUtil.java
@@ -23,6 +23,15 @@ public class DateUtil {
     }
 
     /**
+     * Get current date in formatted string.
+     *
+     * @return Formatted string representation of today's date.
+     */
+    public static String getTodayFormattedDate() {
+        return formatDate(getTodayDate());
+    }
+
+    /**
      * Get the date that is number of days after starting date.
      * {@code days} must be non-negative.
      *

--- a/src/main/java/seedu/address/commons/util/LoanSlipUtil.java
+++ b/src/main/java/seedu/address/commons/util/LoanSlipUtil.java
@@ -5,7 +5,6 @@ import static java.util.Objects.requireNonNull;
 import java.awt.Desktop;
 import java.io.File;
 import java.io.IOException;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.logging.Logger;
 import java.util.stream.IntStream;

--- a/src/main/java/seedu/address/commons/util/LoanSlipUtil.java
+++ b/src/main/java/seedu/address/commons/util/LoanSlipUtil.java
@@ -120,9 +120,7 @@ public class LoanSlipUtil {
             float [] pointColumnWidths = {FIRST_ROW_WIDTH, SECOND_ROW_WIDTH, THIRD_ROW_WIDTH};
             Table table = new Table(pointColumnWidths);
             LoanSlipDocument doc = new LoanSlipDocument(document, table);
-            logger.info("genrating liberry loan slip...");
             generateLiberryLoanSlip(doc);
-            logger.info("generated liberry loan slip...");
         } catch (IOException e) {
             throw new LoanSlipException(e.getMessage());
         }
@@ -269,7 +267,7 @@ public class LoanSlipUtil {
         try {
             Desktop.getDesktop().open(currentFile);
         } catch (IOException e) {
-            throw new LoanSlipException("Error in opening loan slip");
+            logger.info("Unable to open");
         }
     }
 }

--- a/src/main/java/seedu/address/commons/util/LoanSlipUtil.java
+++ b/src/main/java/seedu/address/commons/util/LoanSlipUtil.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.awt.Desktop;
 import java.io.File;
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.logging.Logger;
 import java.util.stream.IntStream;
@@ -117,7 +118,7 @@ public class LoanSlipUtil {
             requireNonNull(currentBooks);
             requireNonNull(currentBorrower);
             Document document = createDocument(createFileNameFromLoan());
-            float [] pointColumnWidths = {FIRST_ROW_WIDTH, SECOND_ROW_WIDTH, THIRD_ROW_WIDTH};
+            float[] pointColumnWidths = {FIRST_ROW_WIDTH, SECOND_ROW_WIDTH, THIRD_ROW_WIDTH};
             Table table = new Table(pointColumnWidths);
             LoanSlipDocument doc = new LoanSlipDocument(document, table);
             generateLiberryLoanSlip(doc);
@@ -191,6 +192,7 @@ public class LoanSlipUtil {
     private static void writeHeaderToDoc(LoanSlipDocument doc) {
         doc.writeHeader(currentBorrower.getName().toString());
         doc.writeLeftParagraph(currentBorrower.getBorrowerId().toString());
+        doc.writeLeftParagraph(DateUtil.getTodayFormattedDate());
         doc.writeLine();
         doc.writeMidHeader("Books borrowed");
     }

--- a/src/main/java/seedu/address/logic/commands/DoneCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DoneCommand.java
@@ -13,7 +13,7 @@ public class DoneCommand extends ReversibleCommand {
     public static final String COMMAND_WORD = "done";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Returns to List Mode. \n"
             + "Example: " + COMMAND_WORD;
-    public static final String MESSAGE_SUCCESS = "Exited from Serve Mode. ";
+    public static final String MESSAGE_SUCCESS = "Exited from Serve Mode. Loan slip saved in folder 'loan_slips'.";
 
     private String unusedArguments = null;
 

--- a/src/main/java/seedu/address/logic/commands/LoanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LoanCommand.java
@@ -73,7 +73,7 @@ public class LoanCommand extends ReversibleCommand {
         Loan loan = new Loan(LoanIdGenerator.generateLoanId(), toLoan, servingBorrower.getBorrowerId(),
                 DateUtil.getTodayDate(), dueDate);
         Book loanedOutBook = bookToBeLoaned.loanOut(loan);
-        Book updatedLoanedOutBook = loanedOutBook.updateLoanHistory(loan);
+        Book updatedLoanedOutBook = loanedOutBook.addToLoanHistory(loan);
 
         // replace the previous Book object with a new Book object that has a Loan
         model.setBook(bookToBeLoaned, updatedLoanedOutBook);

--- a/src/main/java/seedu/address/logic/commands/RenewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RenewCommand.java
@@ -66,7 +66,7 @@ public class RenewCommand extends ReversibleCommand {
             throw new CommandException(MESSAGE_INVALID_BOOK_DISPLAYED_INDEX);
         }
 
-        Book bookToBeRenewed = lastShownBorrowerBooksList.get((int) index.getZeroBased());
+        Book bookToBeRenewed = lastShownBorrowerBooksList.get(index.getZeroBased());
         if (!bookToBeRenewed.isCurrentlyLoanedOut()) {
             throw new CommandException(String.format(MESSAGE_BOOK_NOT_ON_LOAN, bookToBeRenewed));
         }

--- a/src/main/java/seedu/address/logic/commands/RenewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RenewCommand.java
@@ -12,7 +12,9 @@ import java.time.LocalDate;
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.commons.exceptions.LoanSlipException;
 import seedu.address.commons.util.DateUtil;
+import seedu.address.commons.util.LoanSlipUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.book.Book;
@@ -99,10 +101,18 @@ public class RenewCommand extends ReversibleCommand {
         // update Loan in LoanRecords with extended due date
         model.updateLoan(loanToBeRenewed, renewedLoan);
 
+
         undoCommand = new UnrenewCommand(renewedBook, bookToBeRenewed, renewedLoan, loanToBeRenewed);
         redoCommand = this;
         commandResult = new CommandResult(String.format(MESSAGE_SUCCESS, renewedBook,
                 servingBorrower, extendedDueDate));
+
+        // mount renewed loan
+        try {
+            LoanSlipUtil.mountLoan(renewedLoan, renewedBook, servingBorrower);
+        } catch (LoanSlipException e) {
+            e.printStackTrace(); // Unable to generate loan slip, does not affect loan functionality
+        }
 
         return commandResult;
     }

--- a/src/main/java/seedu/address/logic/commands/RenewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RenewCommand.java
@@ -64,7 +64,7 @@ public class RenewCommand extends ReversibleCommand {
             throw new CommandException(MESSAGE_INVALID_BOOK_DISPLAYED_INDEX);
         }
 
-        Book bookToBeRenewed = lastShownBorrowerBooksList.get(index.getZeroBased());
+        Book bookToBeRenewed = lastShownBorrowerBooksList.get((int) index.getZeroBased());
         if (!bookToBeRenewed.isCurrentlyLoanedOut()) {
             throw new CommandException(String.format(MESSAGE_BOOK_NOT_ON_LOAN, bookToBeRenewed));
         }

--- a/src/main/java/seedu/address/logic/commands/ServeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ServeCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_NO_SUCH_BORROWER_ID;
+import static seedu.address.commons.core.Messages.MESSAGE_STILL_IN_SERVE_MODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BORROWER_ID;
 
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -45,6 +46,11 @@ public class ServeCommand extends ReversibleCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
+        if (model.isServeMode()) {
+            throw new CommandException(String.format(MESSAGE_STILL_IN_SERVE_MODE,
+                    model.getServingBorrower().getName().toString()));
+        }
 
         if (!model.hasBorrowerId(borrowerId)) {
             throw new CommandException(MESSAGE_NO_SUCH_BORROWER_ID);

--- a/src/main/java/seedu/address/logic/commands/ServeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ServeCommand.java
@@ -47,11 +47,6 @@ public class ServeCommand extends ReversibleCommand {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (model.isServeMode()) {
-            throw new CommandException(String.format(MESSAGE_STILL_IN_SERVE_MODE,
-                    model.getServingBorrower().getName().toString()));
-        }
-
         if (!model.hasBorrowerId(borrowerId)) {
             throw new CommandException(MESSAGE_NO_SUCH_BORROWER_ID);
         }

--- a/src/main/java/seedu/address/logic/commands/ServeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ServeCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_NO_SUCH_BORROWER_ID;
-import static seedu.address.commons.core.Messages.MESSAGE_STILL_IN_SERVE_MODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BORROWER_ID;
 
 import seedu.address.logic.commands.exceptions.CommandException;

--- a/src/main/java/seedu/address/logic/commands/UnloanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnloanCommand.java
@@ -51,12 +51,14 @@ public class UnloanCommand extends Command {
         assert(model.hasBook(bookToBeUnloaned));
         assert(bookToBeUnloaned.isCurrentlyLoanedOut());
 
+        Book updatedBookToBeUnloaned = bookToBeUnloaned.deleteFromLoanHistory(loanToBeRemoved);
         // replace the previous Book object with a new Book object that does not have the loan
-        model.setBook(bookToBeUnloaned, unloanedBook);
+        model.setBook(updatedBookToBeUnloaned, unloanedBook);
         model.removeLoan(loanToBeRemoved); // remove Loan object from LoanRecords in model
         model.servingBorrowerRemoveLoan(loanToBeRemoved); // remove Loan object from Borrower's currentLoanList
 
-        LoanSlipUtil.unmountSpecificLoan(loanToBeRemoved, bookToBeUnloaned);
+        LoanSlipUtil.unmountSpecificLoan(loanToBeRemoved, updatedBookToBeUnloaned);
+
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, unloanedBook, model.getServingBorrower()));
     }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -26,6 +26,8 @@ import seedu.address.model.loan.Loan;
  */
 public class AddCommandParser implements Parser<AddCommand> {
 
+    private static final int MAX_TITLE_LENGTH = 60;
+    private static final int MAX_AUTHOR_LENGTH = 60;
     private static final Loan NULL_LOAN = null;
 
     /**
@@ -46,12 +48,12 @@ public class AddCommandParser implements Parser<AddCommand> {
         }
 
         Title title = ParserUtil.parseTitle(argMultimap.getValue(PREFIX_TITLE).get());
-        if (title.toString().length() > 30) {
+        if (title.toString().length() > MAX_TITLE_LENGTH) {
             throw new ParseException(MESSAGE_BOOK_TITLE_TOO_LONG);
         }
 
         Author author = ParserUtil.parseAuthor(argMultimap.getValue(PREFIX_AUTHOR).get());
-        if (author.toString().length() > 30) {
+        if (author.toString().length() > MAX_AUTHOR_LENGTH) {
             throw new ParseException(MESSAGE_AUTHOR_NAME_TOO_LONG);
         }
 

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_AUTHOR_NAME_TOO_LONG;
 import static seedu.address.commons.core.Messages.MESSAGE_BOOK_TITLE_TOO_LONG;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_TOO_MANY_GENRES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_AUTHOR;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GENRE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SERIAL_NUMBER;
@@ -28,6 +29,7 @@ public class AddCommandParser implements Parser<AddCommand> {
 
     private static final int MAX_TITLE_LENGTH = 60;
     private static final int MAX_AUTHOR_LENGTH = 60;
+    private static final int MAX_GENRE_COUNT = 5;
     private static final Loan NULL_LOAN = null;
 
     /**
@@ -57,6 +59,11 @@ public class AddCommandParser implements Parser<AddCommand> {
             throw new ParseException(MESSAGE_AUTHOR_NAME_TOO_LONG);
         }
 
+        Set<Genre> genreList = ParserUtil.parseGenres(argMultimap.getAllValues(PREFIX_GENRE));
+        if (genreList.size() > MAX_GENRE_COUNT) {
+            throw new ParseException(String.format(MESSAGE_TOO_MANY_GENRES, MAX_GENRE_COUNT));
+        }
+
         boolean haveSerialNumber = argMultimap.getValue(PREFIX_SERIAL_NUMBER).isPresent();
         SerialNumber serialNumber;
         if (haveSerialNumber) {
@@ -64,7 +71,6 @@ public class AddCommandParser implements Parser<AddCommand> {
         } else {
             serialNumber = SerialNumberGenerator.generateSerialNumber();
         }
-        Set<Genre> genreList = ParserUtil.parseGenres(argMultimap.getAllValues(PREFIX_GENRE));
         Book book = new Book(title, serialNumber, author, NULL_LOAN, genreList);
         return new AddCommand(book);
     }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_BOOK_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_SERIAL_NUMBER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SERIAL_NUMBER;
@@ -23,9 +24,11 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
+        boolean isIndex = false;
         try {
             ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_SERIAL_NUMBER);
             if (isPrefixPresent(argMultimap, PREFIX_SERIAL_NUMBER)) {
+                isIndex = false;
                 //attempting to delete by serial number
                 SerialNumber sn = ParserUtil.parseSerialNumber(argMultimap.getValue(PREFIX_SERIAL_NUMBER).get());
                 return new DeleteBySerialNumberCommand(sn);
@@ -38,6 +41,9 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
             if (serialNumberProvided(args)) {
                 throw new ParseException(
                         String.format(MESSAGE_INVALID_SERIAL_NUMBER, DeleteCommand.MESSAGE_USAGE), pe);
+            } else if (indexProvided(args)) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_BOOK_DISPLAYED_INDEX, DeleteCommand.MESSAGE_USAGE), pe);
             } else {
                 throw new ParseException(
                         String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
@@ -56,6 +62,10 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         // Therefore, if the serial number prefix is present, the serial number provided is invalid.
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_SERIAL_NUMBER);
         return isPrefixPresent(argMultimap, PREFIX_SERIAL_NUMBER);
+    }
+
+    private boolean indexProvided(String args) {
+        return args.trim().matches("^[0-9]*$");
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -27,7 +27,7 @@ import seedu.address.model.usersettings.RenewPeriod;
  */
 public class ParserUtil {
 
-    public static final String MESSAGE_INVALID_INDEX = "Index should be a non-zero positive integer.";
+    public static final String MESSAGE_INVALID_INDEX = "Index should be a non-zero unsigned integer.";
     public static final String MESSAGE_INVALID_DOLLAR_AMOUNT =
             "Dollar amount should be a non-zero number with at most 2 decimal places.";
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -27,7 +27,7 @@ import seedu.address.model.usersettings.RenewPeriod;
  */
 public class ParserUtil {
 
-    public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_INVALID_INDEX = "Index should be a non-zero positive integer.";
     public static final String MESSAGE_INVALID_DOLLAR_AMOUNT =
             "Dollar amount should be a non-zero number with at most 2 decimal places.";
 

--- a/src/main/java/seedu/address/model/book/Book.java
+++ b/src/main/java/seedu/address/model/book/Book.java
@@ -134,12 +134,12 @@ public class Book implements Comparable<Book> {
     }
 
     /**
-     * Updates the loan history of a book.
+     * Adds to the loan history of a book.
      *
      * @param loan {@code Loan} to be added into the history.
      * @return a new {@code Book} with the added loan history.
      */
-    public Book updateLoanHistory(Loan loan) {
+    public Book addToLoanHistory(Loan loan) {
         LoanList newHistory = new LoanList();
         this.getLoanHistory().forEach(currentLoan -> newHistory.add(currentLoan));
         newHistory.add(loan);
@@ -151,6 +151,30 @@ public class Book implements Comparable<Book> {
                 this.getGenres(),
                 newHistory);
     }
+
+    /**
+     * Deletes from the loan history of a book.
+     *
+     * @param loan {@code Loan} to be added into the history.
+     * @return a new {@code Book} with the added loan history.
+     */
+    public Book deleteFromLoanHistory(Loan loan) {
+        LoanList newHistory = new LoanList();
+        assert newHistory.contains(loan);
+        this.getLoanHistory().forEach(currentLoan -> {
+            if (!currentLoan.equals(loan)) {
+                newHistory.add(currentLoan);
+            }
+        });
+        return new Book(
+                this.getTitle(),
+                this.getSerialNumber(),
+                this.getAuthor(),
+                this.getLoan().orElse(NULL_LOAN),
+                this.getGenres(),
+                newHistory);
+    }
+
 
     public int compareTo(Book b) {
         return this.getSerialNumber().compareTo(b.getSerialNumber());

--- a/src/main/java/seedu/address/model/genre/Genre.java
+++ b/src/main/java/seedu/address/model/genre/Genre.java
@@ -11,7 +11,9 @@ public class Genre {
 
     public static final String MESSAGE_CONSTRAINTS = "Genre names should be alphanumeric "
             + "& hyphenated if needed";
+    public static final String MESSAGE_LENGTH_CONSTRAINTS = "Genre names should be at most 30 characters long";
     public static final String VALIDATION_REGEX = "[[A-Z]\\d][\\-[A-Z]\\d]*";
+    public static final int MAX_GENRE_LENGTH = 30;
 
     public final String genreName;
 
@@ -24,6 +26,7 @@ public class Genre {
         requireNonNull(genreName);
         String uppercaseGenreName = genreName.toUpperCase();
         checkArgument(isValidGenreName(uppercaseGenreName), MESSAGE_CONSTRAINTS);
+        checkArgument(isValidGenreLength(uppercaseGenreName), MESSAGE_LENGTH_CONSTRAINTS);
         this.genreName = uppercaseGenreName;
     }
 
@@ -32,6 +35,10 @@ public class Genre {
      */
     public static boolean isValidGenreName(String test) {
         return test.matches(VALIDATION_REGEX);
+    }
+
+    public static boolean isValidGenreLength(String test) {
+        return test.length() <= MAX_GENRE_LENGTH;
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -171,10 +171,6 @@ public class MainWindow extends UiPart<Stage> {
         borrowerPanel.reset();
     }
 
-    public BookListPanel getBookListPanel() {
-        return bookListPanel;
-    }
-
     /**
      * Executes the command and returns the result.
      *

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -172,6 +172,13 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
+     * Observer method invoked when changes happen.
+     */
+    public void update() {
+        updateBorrowerPanel();
+    }
+
+    /**
      * Executes the command and returns the result.
      *
      * @see seedu.address.logic.Logic#execute(String)

--- a/src/test/java/seedu/address/commons/util/DateUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/DateUtilTest.java
@@ -109,4 +109,14 @@ class DateUtilTest {
     public void formatDate() {
         assertEquals(DateUtil.formatDate(LocalDate.of(2019, 10, 25)), "25/10/2019");
     }
+
+    @Test
+    public void getTodayFormattedDate() {
+        LocalDate todaysDate = DateUtil.getTodayDate();
+        String day = todaysDate.getDayOfMonth() < 10
+                ? "0" + todaysDate.getDayOfMonth()
+                : "" + todaysDate.getDayOfMonth();
+        assertEquals(DateUtil.getTodayFormattedDate(),
+                day + "/" + todaysDate.getMonthValue() + "/" + todaysDate.getYear());
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/LoanCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/LoanCommandTest.java
@@ -58,7 +58,7 @@ class LoanCommandTest {
         Loan loan = new Loan(new LoanId("L000001"), toLoan, servingBorrowerId,
                 DateUtil.getTodayDate(), DateUtil.getTodayPlusDays(DEFAULT_LOAN_PERIOD));
         Book loanedOutBook = BOOK_1.loanOut(loan);
-        Book updatedLoanedOutBook = loanedOutBook.updateLoanHistory(loan);
+        Book updatedLoanedOutBook = loanedOutBook.addToLoanHistory(loan);
 
         String actualMessage;
         try {

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -37,8 +37,9 @@ import seedu.address.testutil.BookBuilder;
 
 public class AddCommandParserTest {
     private static final String EXTRA_CHAR = "a";
-    private static final String LONG_TITLE_BOOK = "qwertyuiopasdfghjklzxcvbnmqwer"; // 30 char long
-    private static final String LONG_TITLE_DESC_BOOK = " t/qwertyuiopasdfghjklzxcvbnmqwer"; // 30 char long with prefix
+    private static final String NAME_60_CHARACTER_LENGTH =
+            "1234567890" + "1234567890" + "1234567890" + "1234567890" + "1234567890" + "1234567890";
+    private static final String LONG_TITLE_DESC_BOOK = " t/" + NAME_60_CHARACTER_LENGTH; // 60 char long with prefix
 
     private AddCommandParser parser = new AddCommandParser();
 
@@ -118,7 +119,7 @@ public class AddCommandParserTest {
     @Test
     public void parse_titleCorrectLength_success() {
         Book toAdd = new BookBuilder()
-                .withTitle(LONG_TITLE_BOOK)
+                .withTitle(NAME_60_CHARACTER_LENGTH)
                 .withSerialNumber(VALID_SERIAL_NUMBER_BOOK_1)
                 .withAuthor(VALID_AUTHOR_BOOK_2)
                 .build();

--- a/src/test/java/seedu/address/model/book/BookTest.java
+++ b/src/test/java/seedu/address/model/book/BookTest.java
@@ -18,6 +18,8 @@ import seedu.address.testutil.BookBuilder;
 
 public class BookTest {
 
+
+
     @Test
     public void asObservableList_modifyList_throwsUnsupportedOperationException() {
         Book book = new BookBuilder().build();

--- a/src/test/java/seedu/address/model/book/SerialNumberTest.java
+++ b/src/test/java/seedu/address/model/book/SerialNumberTest.java
@@ -116,4 +116,5 @@ public class SerialNumberTest {
             assertTrue(true);
         }
     }
+
 }

--- a/src/test/java/seedu/address/model/genre/GenreTest.java
+++ b/src/test/java/seedu/address/model/genre/GenreTest.java
@@ -7,6 +7,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import org.junit.jupiter.api.Test;
 
 public class GenreTest {
+    public static final String NAME_29_CHARACTER_LENGTH = "12345678901234567890123456789";
 
     @Test
     public void constructor_null_throwsNullPointerException() {
@@ -42,12 +43,18 @@ public class GenreTest {
         assertFalse(Genre.isValidGenreName("Operations +-*/~`")); // +-*/~`
         assertFalse(Genre.isValidGenreName("PETER*")); // contains non-alphanumeric characters
 
+        // invalid length
+        assertFalse(Genre.isValidGenreLength(NAME_29_CHARACTER_LENGTH + "aa"));
+
         // valid name
         assertTrue(Genre.isValidGenreName("A")); // 1 Alphabet
         assertTrue(Genre.isValidGenreName("0")); // 1 Number
         assertTrue(Genre.isValidGenreName("12345")); // numbers only
         assertTrue(Genre.isValidGenreName("FICTION")); // UPPERCASE
         assertTrue(Genre.isValidGenreName("NON-FICTION")); // UPPERCASE with hyphen
+
+        assertTrue(Genre.isValidGenreLength(NAME_29_CHARACTER_LENGTH));
+        assertTrue(Genre.isValidGenreLength(NAME_29_CHARACTER_LENGTH + "a"));
     }
 
 }


### PR DESCRIPTION
Changes:
- Add today's date to loan slip (Closes #231)
- Index invalid message even for indices larger than Integer.MAX_VALUE (closes #207)
- Renewed loans now shown in loan slip (closes #215)
- Limit genre name length to 30 characters and number of genres per book to 5 (closes #202)