### PR TITLE
Delete command bug fixes and tests

### DIFF
--- a/src/main/java/seedu/address/commons/util/LoanSlipUtil.java
+++ b/src/main/java/seedu/address/commons/util/LoanSlipUtil.java
@@ -6,6 +6,7 @@ import java.awt.Desktop;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.logging.Logger;
 import java.util.stream.IntStream;
 
@@ -35,8 +36,9 @@ public class LoanSlipUtil {
 
     private static final int FIRST_INDEX = 0;
 
-    private static ArrayList<Loan> currentLoans;
-    private static ArrayList<Book> currentBooks;
+    private static HashSet<Loan> loansInCurrentSession = new HashSet<>();
+    private static ArrayList<Loan> currentLoans = new ArrayList<>();
+    private static ArrayList<Book> currentBooks = new ArrayList<>();
     private static Borrower currentBorrower;
 
     private static File currentFile;
@@ -60,12 +62,9 @@ public class LoanSlipUtil {
         if (!loan.getBookSerialNumber().equals(book.getSerialNumber())) {
             throw new LoanSlipException("Book and Loan do not match!");
         }
-        if (!isMounted) {
-            currentLoans = new ArrayList<>();
-            currentBooks = new ArrayList<>();
-        }
         currentLoans.add(loan);
         currentBooks.add(book);
+        loansInCurrentSession.add(loan);
         if (currentBorrower != null) {
             assert currentBorrower.equals(borrower) : "Wrong borrower";
         } else {
@@ -78,15 +77,36 @@ public class LoanSlipUtil {
     /**
      * Unmounts a Loan slip after creating a pdf of it.
      */
-    public static void unmountLoans() {
+    private static void unmountLoans() {
         if (isMounted) {
-            currentLoans = null;
-            currentBooks = null;
+            currentLoans = new ArrayList<>();
+            currentBooks = new ArrayList<>();
             currentBorrower = null;
             currentFile = null;
             isMounted = false;
             isGenerated = false;
         }
+    }
+
+    /**
+     * Clears the current Serve Mode session.
+     */
+    public static void clearSession() {
+        if (isMounted) {
+            unmountLoans();
+        }
+        if (loansInCurrentSession != null) {
+            loansInCurrentSession.clear();
+        }
+    }
+
+    /**
+     * Returns true if loan is in current session.
+     * @param loan loan to check against
+     * @return true if loan is in current session.
+     */
+    public static boolean loanIsInSession(Loan loan) {
+        return loansInCurrentSession.contains(loan);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -60,7 +60,7 @@ public class LogicManager implements Logic {
                     logger.info("making new loan slip");
                     storage.storeNewLoanSlip();
                     LoanSlipUtil.openGeneratedLoanSlip();
-                    LoanSlipUtil.unmountLoans();
+                    LoanSlipUtil.clearSession();
                 }
             }
         } catch (IOException ioe) {

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -20,10 +20,13 @@ public class CommandResult {
     /** The application should exit. */
     private final boolean exit;
 
+    /** The application is serving a borrower */
     private final boolean serve;
 
+    /** The application is done serving a borrower */
     private final boolean done;
 
+    /** The application is showing information about a book*/
     private final Optional<Book> info;
 
     /**

--- a/src/main/java/seedu/address/logic/commands/DeleteByIndexCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteByIndexCommand.java
@@ -12,6 +12,7 @@ import seedu.address.commons.util.LoanSlipUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.book.Book;
+import seedu.address.model.borrower.Borrower;
 import seedu.address.model.loan.Loan;
 
 /**
@@ -36,6 +37,8 @@ public class DeleteByIndexCommand extends DeleteCommand {
         }
         Book bookToDelete = lastShownList.get(targetIndex.getZeroBased());
         if (bookToDelete.isCurrentlyLoanedOut()) {
+            Borrower borrower = model.getBorrowerFromId(bookToDelete.getLoan().get().getBorrowerId());
+            model.setServingBorrower(borrower);
             Loan loanToBeReturned = bookToDelete.getLoan().get();
             LocalDate returnDate = DateUtil.getTodayDate();
             Loan returnedLoan = loanToBeReturned.returnLoan(returnDate, FINE_AMOUNT_ZERO);
@@ -45,6 +48,7 @@ public class DeleteByIndexCommand extends DeleteCommand {
 
             // mark book as returned
             super.markBookAsReturned(model, bookToDelete, returnedBook, loanToBeReturned, returnedLoan);
+            model.exitsServeMode();
             undoCommand = new UndeleteCommand(returnedBook, bookToDelete, returnedLoan, loanToBeReturned);
         } else {
             undoCommand = new AddCommand(bookToDelete);

--- a/src/main/java/seedu/address/logic/commands/DeleteByIndexCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteByIndexCommand.java
@@ -2,18 +2,13 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import java.time.LocalDate;
 import java.util.List;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
-import seedu.address.commons.util.DateUtil;
-import seedu.address.commons.util.LoanSlipUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.book.Book;
-import seedu.address.model.borrower.Borrower;
-import seedu.address.model.loan.Loan;
 
 /**
  * Deletes a book identified using it's displayed index from the catalog.
@@ -36,23 +31,8 @@ public class DeleteByIndexCommand extends DeleteCommand {
             throw new CommandException(Messages.MESSAGE_INVALID_BOOK_DISPLAYED_INDEX);
         }
         Book bookToDelete = lastShownList.get(targetIndex.getZeroBased());
-        if (bookToDelete.isCurrentlyLoanedOut()) {
-            Borrower borrower = model.getBorrowerFromId(bookToDelete.getLoan().get().getBorrowerId());
-            model.setServingBorrower(borrower);
-            Loan loanToBeReturned = bookToDelete.getLoan().get();
-            LocalDate returnDate = DateUtil.getTodayDate();
-            Loan returnedLoan = loanToBeReturned.returnLoan(returnDate, FINE_AMOUNT_ZERO);
 
-            Book returnedBook = bookToDelete.returnBook();
-            LoanSlipUtil.unmountSpecificLoan(loanToBeReturned, bookToDelete);
-
-            // mark book as returned
-            super.markBookAsReturned(model, bookToDelete, returnedBook, loanToBeReturned, returnedLoan);
-            model.exitsServeMode();
-            undoCommand = new UndeleteCommand(returnedBook, bookToDelete, returnedLoan, loanToBeReturned);
-        } else {
-            undoCommand = new AddCommand(bookToDelete);
-        }
+        returnBook(model, bookToDelete); // return before deleting
 
         model.deleteBook(bookToDelete);
 

--- a/src/main/java/seedu/address/logic/commands/DeleteBySerialNumberCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteBySerialNumberCommand.java
@@ -2,16 +2,11 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import java.time.LocalDate;
-
 import seedu.address.commons.core.Messages;
-import seedu.address.commons.util.DateUtil;
-import seedu.address.commons.util.LoanSlipUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.book.Book;
 import seedu.address.model.book.SerialNumber;
-import seedu.address.model.loan.Loan;
 
 /**
  * Deletes a book identified using it's serial number from the catalog.

--- a/src/main/java/seedu/address/logic/commands/UndeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndeleteCommand.java
@@ -38,8 +38,17 @@ public class UndeleteCommand extends Command {
         // update Book in model to have Loan removed
         model.setBook(bookToBeLoaned, loanedBook);
 
+        boolean wasServeMode = model.isServeMode();
+
+        if (!wasServeMode) {
+            model.setServingBorrower(loanToBeAdded.getBorrowerId());
+        }
         // remove Loan from Borrower's currentLoanList and move to Borrower's returnedLoanList
         model.servingBorrowerUnreturnLoan(loanToBeAdded, addedLoan);
+
+        if (!wasServeMode) {
+            model.exitsServeMode();
+        }
 
         // update Loan in LoanRecords with returnDate and remainingFineAmount
         model.updateLoan(loanToBeAdded, addedLoan);

--- a/src/main/java/seedu/address/logic/commands/UnrenewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnrenewCommand.java
@@ -8,6 +8,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.util.ArrayList;
 
 import seedu.address.commons.util.DateUtil;
+import seedu.address.commons.util.LoanSlipUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.book.Book;
@@ -77,6 +78,8 @@ public class UnrenewCommand extends Command {
 
             // update Loan in LoanRecords to previous due date
             model.updateLoan(loanToBeUnrenewed, unrenewedLoan);
+
+            LoanSlipUtil.unmountSpecificLoan(loanToBeUnrenewed, bookToBeUnrenewed);
 
             feedbackMessage += String.format(MESSAGE_SUCCESS, unrenewedBook, servingBorrower,
                     DateUtil.formatDate(unrenewedLoan.getDueDate()));

--- a/src/main/java/seedu/address/logic/commands/UnreturnCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnreturnCommand.java
@@ -79,7 +79,9 @@ public class UnreturnCommand extends Command {
             model.updateLoan(loanToBeUnreturned, unreturnedLoan);
 
             try {
-                LoanSlipUtil.mountLoan(unreturnedLoan, unreturnedBook, model.getServingBorrower());
+                if (LoanSlipUtil.loanIsInSession(unreturnedLoan)) {
+                    LoanSlipUtil.mountLoan(unreturnedLoan, unreturnedBook, model.getServingBorrower());
+                }
             } catch (LoanSlipException e) {
                 e.printStackTrace(); // Unable to generate loan slip, does not affect loan functionality
             }

--- a/src/main/java/seedu/address/model/book/Book.java
+++ b/src/main/java/seedu/address/model/book/Book.java
@@ -159,8 +159,8 @@ public class Book implements Comparable<Book> {
      * @return a new {@code Book} with the added loan history.
      */
     public Book deleteFromLoanHistory(Loan loan) {
+        assert getLoanHistory().contains(loan) : "Loan history does not contain loan to be deleted.";
         LoanList newHistory = new LoanList();
-        assert newHistory.contains(loan);
         this.getLoanHistory().forEach(currentLoan -> {
             if (!currentLoan.equals(loan)) {
                 newHistory.add(currentLoan);
@@ -227,25 +227,6 @@ public class Book implements Comparable<Book> {
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
         return Objects.hash(title, serialNumber, author, genres);
-    }
-
-    /**
-     * Method to return the full string representation of the book, if required.
-     *
-     * @return Full string representation of book.
-     */
-    public String toFullString() {
-        final StringBuilder builder = new StringBuilder();
-        builder.append(getTitle())
-                .append(", Serial Number: ")
-                .append(getSerialNumber())
-                .append(", Author: ")
-                .append(getAuthor());
-        if (!getGenres().isEmpty()) {
-            builder.append(", Genres: ");
-            getGenres().forEach(genre -> builder.append(genre + " "));
-        }
-        return builder.toString();
     }
 
     /**

--- a/src/main/java/seedu/address/model/book/UniqueBookList.java
+++ b/src/main/java/seedu/address/model/book/UniqueBookList.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 
@@ -150,13 +151,7 @@ public class UniqueBookList implements Iterable<Book> {
      * Returns true if {@code books} contains only unique books.
      */
     private boolean booksAreUnique(List<Book> books) {
-        for (int i = 0; i < books.size() - 1; i++) {
-            for (int j = i + 1; j < books.size(); j++) {
-                if (books.get(i).equals(books.get(j))) {
-                    return false;
-                }
-            }
-        }
-        return true;
+        HashSet<Book> bookSet = new HashSet<>(books);
+        return bookSet.size() == books.size();
     }
 }

--- a/src/main/java/seedu/address/model/loan/LoanList.java
+++ b/src/main/java/seedu/address/model/loan/LoanList.java
@@ -37,6 +37,7 @@ public class LoanList implements Iterable<Loan> {
     public LoanList addToNewCopy(Loan loan) {
         ArrayList<Loan> newList = new ArrayList<>(this.loanList);
         newList.add(loan);
+        Collections.sort(newList);
         return new LoanList(newList);
     }
 

--- a/src/test/java/seedu/address/commons/util/LoanSlipUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/LoanSlipUtilTest.java
@@ -54,7 +54,7 @@ class LoanSlipUtilTest {
 
     @Test
     public void mountLoanSlip_noLoanSlipMounted_success() {
-        LoanSlipUtil.unmountLoans();
+        LoanSlipUtil.clearSession();
         assertFalse(LoanSlipUtil.isMounted());
         assertDoesNotThrow(() -> LoanSlipUtil.mountLoan(loan, book, borrower));
         assertTrue(LoanSlipUtil.isMounted());
@@ -62,7 +62,7 @@ class LoanSlipUtilTest {
 
     @Test
     public void mountLoanSlip_inconsistentLoanAndFields_failure() {
-        LoanSlipUtil.unmountLoans();
+        LoanSlipUtil.clearSession();
         assertThrows(LoanSlipException.class, () -> LoanSlipUtil.mountLoan(loan, BOOK_2, borrower));
         assertFalse(LoanSlipUtil.isMounted());
         assertThrows(LoanSlipException.class, () -> LoanSlipUtil.mountLoan(loan, book, BOB));
@@ -71,7 +71,7 @@ class LoanSlipUtilTest {
 
     @Test
     public void mountLoanSlip_loanSlipMountedDifferentBorrower_failure() {
-        LoanSlipUtil.unmountLoans();
+        LoanSlipUtil.clearSession();
         assertFalse(LoanSlipUtil.isMounted());
         //Mount first loan
         assertDoesNotThrow(() -> LoanSlipUtil.mountLoan(loan, book, borrower));
@@ -82,7 +82,7 @@ class LoanSlipUtilTest {
 
     @Test
     public void mountLoanSlip_loanSlipMountedSameBorrower_success() {
-        LoanSlipUtil.unmountLoans();
+        LoanSlipUtil.clearSession();
         assertFalse(LoanSlipUtil.isMounted());
         //Mount first loan
         assertDoesNotThrow(() -> LoanSlipUtil.mountLoan(loan, book, borrower));
@@ -109,7 +109,7 @@ class LoanSlipUtilTest {
 
     @Test
     public void openLoanSlip_loanSlipNotReady_failure() {
-        LoanSlipUtil.unmountLoans();
+        LoanSlipUtil.clearSession();
         assertThrows(LoanSlipException.class, () -> LoanSlipUtil.openGeneratedLoanSlip());
         assertDoesNotThrow(() -> LoanSlipUtil.mountLoan(loan, book, borrower));
         assertThrows(LoanSlipException.class, () -> LoanSlipUtil.openGeneratedLoanSlip());
@@ -118,14 +118,14 @@ class LoanSlipUtilTest {
     @Test
     public void unmountSpecificLoan_success() {
         // Unmount loan, loan not mounted, nothing happens
-        LoanSlipUtil.unmountLoans();
+        LoanSlipUtil.clearSession();
         assertFalse(LoanSlipUtil.isMounted());
         //Mount first loan
         assertDoesNotThrow(() -> LoanSlipUtil.mountLoan(loan, book, borrower));
         assertDoesNotThrow(() -> LoanSlipUtil.unmountSpecificLoan(loan2, BOOK_2));
 
         // Unmount loan, only 1 loan mounted, entire LoanSlipUtil is unmounted
-        LoanSlipUtil.unmountLoans();
+        LoanSlipUtil.clearSession();
         assertFalse(LoanSlipUtil.isMounted());
         //Mount first loan
         assertDoesNotThrow(() -> LoanSlipUtil.mountLoan(loan, book, borrower));
@@ -133,7 +133,7 @@ class LoanSlipUtilTest {
         assertFalse(LoanSlipUtil.isMounted());
 
         //Unmount loan, still have other loans mounted, LoanSlipUtil is still mounted
-        LoanSlipUtil.unmountLoans();
+        LoanSlipUtil.clearSession();
         assertFalse(LoanSlipUtil.isMounted());
         //Mount first loan two loans
         assertDoesNotThrow(() -> LoanSlipUtil.mountLoan(loan, book, borrower));

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -1,10 +1,14 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalBooks.BOOK_1;
+import static seedu.address.testutil.TypicalBooks.BOOK_2;
 
 import org.junit.jupiter.api.Test;
 
@@ -42,6 +46,12 @@ public class CommandResultTest {
 
         // different info value -> returns false
         assertFalse(commandResult.equals(CommandResult.commandResultInfo("feedback", BOOK_1)));
+
+        CommandResult commandResult1 = CommandResult.commandResultInfo("info", BOOK_1);
+        CommandResult commandResult2 = CommandResult.commandResultInfo("info", BOOK_2);
+
+        assertNotEquals(commandResult1, commandResult2);
+        assertNotEquals(commandResult, commandResult2);
     }
 
     @Test
@@ -82,6 +92,12 @@ public class CommandResultTest {
 
         CommandResult commandResult2 = CommandResult.commandResultHelp("feedback");
         assertTrue(commandResult2.isShowHelp());
+        assertFalse(commandResult1.isExit());
+        assertFalse(commandResult1.isServe());
+        assertFalse(commandResult1.isDone());
+        assertFalse(commandResult1.isInfo());
+
+        assertThrows(AssertionError.class, () -> commandResult2.getBook());
     }
 
     @Test
@@ -91,6 +107,12 @@ public class CommandResultTest {
 
         CommandResult commandResult2 = CommandResult.commandResultExit("feedback");
         assertTrue(commandResult2.isExit());
+        assertFalse(commandResult1.isShowHelp());
+        assertFalse(commandResult1.isServe());
+        assertFalse(commandResult1.isDone());
+        assertFalse(commandResult1.isInfo());
+
+        assertThrows(AssertionError.class, () -> commandResult2.getBook());
     }
 
     @Test
@@ -100,6 +122,12 @@ public class CommandResultTest {
 
         CommandResult commandResult2 = CommandResult.commandResultServe("feedback");
         assertTrue(commandResult2.isServe());
+        assertFalse(commandResult1.isShowHelp());
+        assertFalse(commandResult1.isExit());
+        assertFalse(commandResult1.isDone());
+        assertFalse(commandResult1.isInfo());
+
+        assertThrows(AssertionError.class, () -> commandResult2.getBook());
     }
 
     @Test
@@ -109,5 +137,27 @@ public class CommandResultTest {
 
         CommandResult commandResult2 = CommandResult.commandResultDone("feedback");
         assertTrue(commandResult2.isDone());
+        assertFalse(commandResult1.isShowHelp());
+        assertFalse(commandResult1.isExit());
+        assertFalse(commandResult1.isServe());
+        assertFalse(commandResult1.isInfo());
+
+        assertThrows(AssertionError.class, () -> commandResult2.getBook());
+    }
+
+    @Test
+    public void isInfo() {
+        CommandResult commandResult1 = new CommandResult("feedback");
+        assertFalse(commandResult1.isInfo());
+
+        CommandResult commandResult2 = CommandResult.commandResultInfo("feedback", BOOK_1);
+        assertTrue(commandResult2.isInfo());
+        assertFalse(commandResult1.isShowHelp());
+        assertFalse(commandResult1.isExit());
+        assertFalse(commandResult1.isServe());
+        assertFalse(commandResult1.isDone());
+
+        assertDoesNotThrow(() -> commandResult2.getBook());
+        assertEquals(BOOK_1, commandResult2.getBook());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteByIndexCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteByIndexCommandTest.java
@@ -149,12 +149,7 @@ public class DeleteByIndexCommandTest {
 
         DeleteByIndexCommand deleteByIndexCommand = new DeleteByIndexCommand(INDEX_FIRST_BOOK);
 
-        Book returned  = updatedLoanedOutBook.returnBook();
-
-        LocalDate returnDate = DateUtil.getTodayDate();
-        Loan returnedLoan = loan.returnLoan(returnDate, FINE_AMOUNT_ZERO);
-
-        deleteByIndexCommand.markBookAsReturned(model, loanedOutBook, returned, loan, returnedLoan);
+        deleteByIndexCommand.returnBook(model, loanedOutBook);
         Book result2 = model.getBook(target.getSerialNumber());
         assertFalse(result2.isCurrentlyLoanedOut());
 

--- a/src/test/java/seedu/address/logic/commands/DeleteByIndexCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteByIndexCommandTest.java
@@ -139,7 +139,7 @@ public class DeleteByIndexCommandTest {
         Book updatedLoanedOutBook = loanedOutBook.addToLoanHistory(loan);
 
         try {
-            LoanSlipUtil.unmountLoans();
+            LoanSlipUtil.clearSession();
             loanCommand.execute(model).getFeedbackToUser();
         } catch (CommandException e) {
             assert false : "Command should not fail here";

--- a/src/test/java/seedu/address/logic/commands/DeleteByIndexCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteByIndexCommandTest.java
@@ -2,10 +2,10 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showBookAtIndex;
-import static seedu.address.logic.commands.DeleteCommand.FINE_AMOUNT_ZERO;
 import static seedu.address.testutil.TypicalBooks.BOOK_1;
 import static seedu.address.testutil.TypicalBooks.getTypicalCatalog;
 import static seedu.address.testutil.TypicalBorrowers.HOON;
@@ -14,8 +14,6 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_BOOK;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_BOOK;
 import static seedu.address.testutil.TypicalLoans.LOAN_1;
 import static seedu.address.testutil.UserSettingsBuilder.DEFAULT_LOAN_PERIOD;
-
-import java.time.LocalDate;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/commands/DeleteByIndexCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteByIndexCommandTest.java
@@ -5,20 +5,36 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showBookAtIndex;
+import static seedu.address.logic.commands.DeleteCommand.FINE_AMOUNT_ZERO;
+import static seedu.address.testutil.TypicalBooks.BOOK_1;
 import static seedu.address.testutil.TypicalBooks.getTypicalCatalog;
+import static seedu.address.testutil.TypicalBorrowers.HOON;
+import static seedu.address.testutil.TypicalBorrowers.getTypicalBorrowerRecords;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_BOOK;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_BOOK;
+import static seedu.address.testutil.TypicalLoans.LOAN_1;
+import static seedu.address.testutil.UserSettingsBuilder.DEFAULT_LOAN_PERIOD;
+
+import java.time.LocalDate;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.DateUtil;
+import seedu.address.commons.util.LoanSlipUtil;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.BorrowerRecords;
 import seedu.address.model.LoanRecords;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.book.Book;
+import seedu.address.model.book.SerialNumber;
+import seedu.address.model.borrower.BorrowerId;
+import seedu.address.model.loan.Loan;
+import seedu.address.model.loan.LoanId;
+import seedu.address.testutil.BookBuilder;
 
 /**
  * Contains integration tests (interaction with the Model, UndoCommand and RedoCommand) and unit tests for
@@ -27,18 +43,19 @@ import seedu.address.model.book.Book;
 public class DeleteByIndexCommandTest {
     // TODO implement and add getTypicalLoanRecords() and getTypicalBorrowerRecords()
     private Model model = new ModelManager(
-            getTypicalCatalog(), new LoanRecords(), new BorrowerRecords(), new UserPrefs());
+            getTypicalCatalog(), new LoanRecords(), getTypicalBorrowerRecords(), new UserPrefs());
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Book bookToDelete = model.getFilteredBookList().get(INDEX_FIRST_BOOK.getZeroBased());
+        Book loanedBookToDelete = bookToDelete.loanOut(LOAN_1);
         DeleteByIndexCommand deleteByIndexCommand = new DeleteByIndexCommand(INDEX_FIRST_BOOK);
 
-        String expectedMessage = String.format(DeleteByIndexCommand.MESSAGE_DELETE_BOOK_SUCCESS, bookToDelete);
+        String expectedMessage = String.format(DeleteByIndexCommand.MESSAGE_DELETE_BOOK_SUCCESS, loanedBookToDelete);
 
         ModelManager expectedModel = new ModelManager(
                 model.getCatalog(), model.getLoanRecords(), model.getBorrowerRecords(), new UserPrefs());
-        expectedModel.deleteBook(bookToDelete);
+        expectedModel.deleteBook(loanedBookToDelete);
 
         assertCommandSuccess(deleteByIndexCommand, model, expectedMessage, expectedModel);
     }
@@ -101,6 +118,46 @@ public class DeleteByIndexCommandTest {
 
         // different person -> returns false
         assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
+    }
+
+    @Test
+    public void markBookAsReturned() {
+        SerialNumber toLoan = BOOK_1.getSerialNumber();
+        Book target = new BookBuilder(BOOK_1).build();
+        BorrowerRecords borrowerRecords = new BorrowerRecords();
+        borrowerRecords.addBorrower(HOON);
+        BorrowerId servingBorrowerId = HOON.getBorrowerId();
+
+        model = new ModelManager(getTypicalCatalog(), new LoanRecords(),
+                borrowerRecords, new UserPrefs());
+        model.setServingBorrower(servingBorrowerId);
+
+        LoanCommand loanCommand = new LoanCommand(toLoan);
+
+        Loan loan = new Loan(new LoanId("L000001"), toLoan, servingBorrowerId,
+                DateUtil.getTodayDate(), DateUtil.getTodayPlusDays(DEFAULT_LOAN_PERIOD));
+        Book loanedOutBook = target.loanOut(loan);
+        assertTrue(loanedOutBook.isCurrentlyLoanedOut());
+        Book updatedLoanedOutBook = loanedOutBook.addToLoanHistory(loan);
+
+        try {
+            LoanSlipUtil.unmountLoans();
+            loanCommand.execute(model).getFeedbackToUser();
+        } catch (CommandException e) {
+            assert false : "Command should not fail here";
+        }
+
+        DeleteByIndexCommand deleteByIndexCommand = new DeleteByIndexCommand(INDEX_FIRST_BOOK);
+
+        Book returned  = updatedLoanedOutBook.returnBook();
+
+        LocalDate returnDate = DateUtil.getTodayDate();
+        Loan returnedLoan = loan.returnLoan(returnDate, FINE_AMOUNT_ZERO);
+
+        deleteByIndexCommand.markBookAsReturned(model, loanedOutBook, returned, loan, returnedLoan);
+        Book result2 = model.getBook(target.getSerialNumber());
+        assertFalse(result2.isCurrentlyLoanedOut());
+
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/LoanCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/LoanCommandTest.java
@@ -66,7 +66,7 @@ class LoanCommandTest {
         } catch (CommandException e) {
             actualMessage = e.getMessage();
         } finally {
-            LoanSlipUtil.unmountLoans();
+            LoanSlipUtil.clearSession();
         }
         String expectedMessage = String.format(LoanCommand.MESSAGE_SUCCESS, updatedLoanedOutBook,
                 model.getServingBorrower());
@@ -94,7 +94,7 @@ class LoanCommandTest {
         } catch (CommandException e) {
             actualMessage = e.getMessage();
         } finally {
-            LoanSlipUtil.unmountLoans();
+            LoanSlipUtil.clearSession();
         }
         String expectedMessage = MESSAGE_NOT_IN_SERVE_MODE;
         assertEquals(actualMessage, expectedMessage);
@@ -119,7 +119,7 @@ class LoanCommandTest {
         } catch (CommandException e) {
             actualMessage = e.getMessage();
         } finally {
-            LoanSlipUtil.unmountLoans();
+            LoanSlipUtil.clearSession();
         }
         String expectedMessage = MESSAGE_NO_SUCH_BOOK;
         assertEquals(actualMessage, expectedMessage);
@@ -147,7 +147,7 @@ class LoanCommandTest {
         } catch (CommandException e) {
             actualMessage = e.getMessage();
         } finally {
-            LoanSlipUtil.unmountLoans();
+            LoanSlipUtil.clearSession();
         }
         String expectedMessage = String.format(MESSAGE_BOOK_ON_LOAN, BOOK_7);
         assertEquals(actualMessage, expectedMessage);

--- a/src/test/java/seedu/address/model/book/BookTest.java
+++ b/src/test/java/seedu/address/model/book/BookTest.java
@@ -2,6 +2,7 @@ package seedu.address.model.book;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_AUTHOR_BOOK_2;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_GENRE_ACTION;
@@ -11,14 +12,14 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TITLE_BOOK_2;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalBooks.BOOK_1;
 import static seedu.address.testutil.TypicalBooks.BOOK_2;
+import static seedu.address.testutil.TypicalLoans.LOAN_1;
+import static seedu.address.testutil.TypicalLoans.LOAN_2;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.testutil.BookBuilder;
 
 public class BookTest {
-
-
 
     @Test
     public void asObservableList_modifyList_throwsUnsupportedOperationException() {
@@ -74,42 +75,95 @@ public class BookTest {
     }
 
     @Test
+    public void loanOut() {
+        Book target = new BookBuilder(BOOK_1).build();
+        assertFalse(target.isCurrentlyLoanedOut());
+
+        Book loanedOut = target.loanOut(LOAN_1);
+        assertTrue(loanedOut.isOverdue());
+        assertTrue(loanedOut.isCurrentlyLoanedOut());
+    }
+
+    @Test
+    public void returnBook() {
+        Book target = new BookBuilder(BOOK_1).build();
+        assertFalse(target.isCurrentlyLoanedOut());
+        assertThrows(AssertionError.class, () -> target.returnBook());
+
+        Book loanedOut = target.loanOut(LOAN_1);
+        assertTrue(loanedOut.isCurrentlyLoanedOut());
+        assertThrows(AssertionError.class, () -> loanedOut.loanOut(LOAN_1));
+
+        Book returnedBook = loanedOut.returnBook();
+        assertFalse(returnedBook.isCurrentlyLoanedOut());
+    }
+
+    @Test
+    public void addToLoanHistory() {
+        Book target = new BookBuilder(BOOK_1).build();
+        assertFalse(target.isCurrentlyLoanedOut());
+
+        Book loanedOut = target.loanOut(LOAN_1);
+        assertTrue(loanedOut.isCurrentlyLoanedOut());
+        Book updatedLoanedOut = loanedOut.addToLoanHistory(LOAN_1);
+
+        assertTrue(updatedLoanedOut.getLoanHistory().contains(LOAN_1));
+    }
+
+    @Test
+    public void deleteFromLoanHistory() {
+        Book target = new BookBuilder(BOOK_1).build();
+        assertFalse(target.isCurrentlyLoanedOut());
+
+        Book loanedOut = target.loanOut(LOAN_1);
+        assertTrue(loanedOut.isCurrentlyLoanedOut());
+        assertThrows(AssertionError.class, () -> loanedOut.deleteFromLoanHistory(LOAN_1));
+        Book updatedLoanedOut = loanedOut.addToLoanHistory(LOAN_1);
+        updatedLoanedOut = updatedLoanedOut.addToLoanHistory(LOAN_2);
+
+        assertTrue(updatedLoanedOut.getLoanHistory().contains(LOAN_1));
+
+        Book deletedLoanHistoryBook = updatedLoanedOut.deleteFromLoanHistory(LOAN_1);
+        assertFalse(deletedLoanHistoryBook.getLoanHistory().contains(LOAN_1));
+    }
+
+    @Test
     public void equals() {
         // compares all attributes
         // same values -> returns true
         Book aliceCopy = new BookBuilder(BOOK_1).build();
-        assertTrue(BOOK_1.equals(aliceCopy));
+        assertEquals(BOOK_1, aliceCopy);
 
         // same object -> returns true
-        assertTrue(BOOK_1.equals(BOOK_1));
+        assertEquals(BOOK_1, BOOK_1);
 
         // null -> returns false
-        assertFalse(BOOK_1.equals(null));
+        assertNotEquals(null, BOOK_1);
 
         // different type -> returns false
-        assertFalse(BOOK_1.equals(5));
+        assertNotEquals(5, BOOK_1);
 
         // different person -> returns false
-        assertFalse(BOOK_1.equals(BOOK_2));
+        assertNotEquals(BOOK_1, BOOK_2);
 
         // different name and serial number -> returns false
         Book editedA = new BookBuilder(BOOK_1).withTitle(VALID_TITLE_BOOK_2)
                 .withSerialNumber(VALID_SERIAL_NUMBER_BOOK_2).build();
-        assertFalse(BOOK_1.equals(editedA));
+        assertNotEquals(BOOK_1, editedA);
 
         // different serial number -> returns false
         editedA = new BookBuilder(BOOK_1).withSerialNumber(VALID_SERIAL_NUMBER_BOOK_2).build();
-        assertFalse(BOOK_1.equals(editedA));
+        assertNotEquals(BOOK_1, editedA);
 
         // different author -> returns false
         editedA = new BookBuilder(BOOK_1).withAuthor(VALID_AUTHOR_BOOK_2)
                 .withSerialNumber(VALID_SERIAL_NUMBER_BOOK_2).build();
-        assertFalse(BOOK_1.equals(editedA));
+        assertNotEquals(BOOK_1, editedA);
 
         // different genres -> returns false
         editedA = new BookBuilder(BOOK_1).withGenres(VALID_GENRE_ACTION)
                 .withSerialNumber(VALID_SERIAL_NUMBER_BOOK_2).build();
-        assertFalse(BOOK_1.equals(editedA));
+        assertNotEquals(BOOK_1, editedA);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/book/UniqueBookListTest.java
+++ b/src/test/java/seedu/address/model/book/UniqueBookListTest.java
@@ -167,4 +167,9 @@ public class UniqueBookListTest {
             -> uniqueBookList.asUnmodifiableObservableList().remove(0));
     }
 
+    @Test
+    public void iterator() {
+        uniqueBookList.forEach(book -> assertTrue(uniqueBookList.contains(book)));
+    }
+
 }


### PR DESCRIPTION
- Fix bug to allow delete command to work in both `Normal` and `Serve` modes
- Increase tests coverage for `Delete` class and its subclasses
- Increase tests for `Book` class
- Fix bug (Multiple undo and redo after `return -all` causes multiple entries in loan slip)